### PR TITLE
Add api_docs folder with API guide link

### DIFF
--- a/api_docs/README.md
+++ b/api_docs/README.md
@@ -1,0 +1,8 @@
+# PicoScope API Documentation
+
+This folder is intended to store the official PicoScope API programmer's guide.
+
+The guide can be downloaded from Pico Technology:
+https://www.picotech.com/download/manuals/picoscope-6000-series-a-api-programmers-guide.pdf
+
+Add the PDF here after downloading so that it remains available alongside the code.


### PR DESCRIPTION
## Summary
- add `api_docs` directory for API documentation
- add README linking to the official API programmer's guide

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846cf2a68c4832790b3c8460852606b