### PR TITLE
Add raw api headers directory

### DIFF
--- a/raw_api_header_files/README.md
+++ b/raw_api_header_files/README.md
@@ -1,0 +1,1 @@
+This directory stores header files for the raw API.


### PR DESCRIPTION
## Summary
- add an empty folder for raw API headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pypicosdk')*

------
https://chatgpt.com/codex/tasks/task_e_6846e0bacfd88327aa473647b98dffed