### PR TITLE
Fix mkdocs install in workflow

### DIFF
--- a/.github/workflows/mkdocs_deploy.yml
+++ b/.github/workflows/mkdocs_deploy.yml
@@ -26,9 +26,9 @@ jobs:
       with:
         python-version: "3.12"
 
-    - name: Install dependancies
+  - name: Install dependencies
       run: |
-        pip install mkdocs mkdocstrings-python
+        pip install mkdocs mkdocstrings mkdocstrings-python
 
     - name: Setup git
       run: |


### PR DESCRIPTION
## Summary
- add mkdocs base plugin to deploy workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pypicosdk')*

------
https://chatgpt.com/codex/tasks/task_e_6847041efb1c832793be84667f77ae15