### PR TITLE
Tidy dangling commit and add missing wrapper

### DIFF
--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -459,6 +459,28 @@ class PicoScopeBase:
         return time.value
 
 
+    def get_trigger_info(self, segment_index: int = 0) -> int:
+        """Retrieve trigger timing information.
+
+        Args:
+            segment_index (int, optional): The memory segment to query. Defaults to 0.
+
+        Returns:
+            int: Raw trigger information returned by the driver.
+
+        Raises:
+            PicoSDKException: If the function call fails or preconditions are not met.
+        """
+        info = ctypes.c_uint64()
+        self._call_attr_function(
+            'GetTriggerInfo',
+            self.handle,
+            ctypes.byref(info),
+            segment_index
+        )
+        return info.value
+
+
     
     # Data conversion ADC/mV & ctypes/int 
     def mv_to_adc(self, mv:float, channel_range:int) -> int:


### PR DESCRIPTION
## Summary
- add missing `get_trigger_info` wrapper from lost commit
- prune unused dangling commits

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470fdd494c83278647ee5b27fc9f09