### PR TITLE
Fix YAML in mkdocs deploy workflow

### DIFF
--- a/.github/workflows/mkdocs_deploy.yml
+++ b/.github/workflows/mkdocs_deploy.yml
@@ -11,37 +11,33 @@ on:
       - v*
 
 permissions:
-  contents: write  
+  contents: write
 
 jobs:
   mkdocs-deploy:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
 
-    - name: Install python and mkdocs
-      uses: actions/setup-python@v5.5.0
-      with:
-        python-version: "3.12"
+      - name: Install python and mkdocs
+        uses: actions/setup-python@v5.5.0
+        with:
+          python-version: "3.12"
 
-  - name: Install dependencies
-      run: |
-        pip install mkdocs mkdocstrings mkdocstrings-python
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocstrings mkdocstrings-python
 
-    - name: Setup git
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Setup git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-    - name: Deploy mkdocs
-      run: |
-        cd docs
-        mkdocs gh-deploy --force
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
-
-    
-    
+      - name: Deploy mkdocs
+        run: |
+          cd docs
+          mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- correct indentation in `.github/workflows/mkdocs_deploy.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pypicosdk')*

------
https://chatgpt.com/codex/tasks/task_e_68471256eb04832796d2709214075a4d