### PR TITLE
Fix YAML syntax in mkdocs deploy workflow

### DIFF
--- a/.github/workflows/mkdocs_deploy.yml
+++ b/.github/workflows/mkdocs_deploy.yml
@@ -4,11 +4,11 @@ name: mkdocs deploy
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.
-on:
+"on":
   workflow_dispatch:
   push:
     tags:
-      - v*
+      - "v*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- quote `on` key and tag wildcard to avoid YAML parsing issues

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pypicosdk')*

------
https://chatgpt.com/codex/tasks/task_e_684716383b1c832780c0e60e27e0a6d9