### PR TITLE
Add 6000A streaming mode wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The output should be similar to:
 `JR001/001`
 
 Once tested, try an [example script from github](https://github.com/StuLawPico/pyPicoSDK_Playground) to get started.
+For continuous acquisition see `examples/example_6000a_simple_streaming.py`.
 
 ## Useful links and references
 - [Documentation & Reference](https://stulawpico.github.io/pyPicoSDK_Playground)

--- a/docs/docs/dev/current.md
+++ b/docs/docs/dev/current.md
@@ -1,7 +1,8 @@
 # Functions available pyPicoSDK v0.1
 ## 6000 (A) API
-- Capture Modes 
+- Capture Modes
     - Block Mode (Single Captures)
+    - Streaming Mode (Continuous Capture)
 - Signal Generator
 
 

--- a/docs/docs/dev/roadmap.md
+++ b/docs/docs/dev/roadmap.md
@@ -1,6 +1,7 @@
 # Roadmap for pyPicoSDK
 ## WIP
 - 6000 (A) API Signal Generator
+- 6000 (A) streaming support
 - Documentation
     - Complete docStrings for pypicoSDK
         - Adding constants docstrings
@@ -10,7 +11,6 @@
     - Current in [test pypi](https://test.pypi.org/project/pypicosdk/)
 
 ## To-Do
-- 6000 (A) streaming support
 - Add `run_simple_block_capture()` for 5000 (A)
 - Add support for 3000 (A) drivers
 - Test & add support for macOS & linux

--- a/examples/example_6000a_simple_streaming.py
+++ b/examples/example_6000a_simple_streaming.py
@@ -1,0 +1,32 @@
+import pypicosdk as psdk
+from matplotlib import pyplot as plt
+
+# Setup parameters
+sample_interval = 10  # in nanoseconds
+samples = 5000
+channel = psdk.CHANNEL.A
+rng = psdk.RANGE.V1
+
+# Initialise
+scope = psdk.ps6000a()
+scope.open_unit()
+
+# Channel and trigger
+scope.set_channel(channel=channel, range=rng)
+scope.set_simple_trigger(channel=channel, threshold_mv=0)
+
+# Run streaming capture
+buffers, time_axis = scope.run_simple_streaming_capture(
+    sample_interval,
+    psdk.PICO_TIME_UNIT.NS,
+    samples,
+)
+
+scope.close_unit()
+
+# Plot results
+plt.plot(time_axis, buffers[channel])
+plt.xlabel("Time (ns)")
+plt.ylabel("Amplitude (mV)")
+plt.grid(True)
+plt.show()

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -21,6 +21,31 @@ class PowerSupplyWarning(UserWarning):
     pass
 
 
+# Streaming data structures
+class PICO_STREAMING_DATA_INFO(ctypes.Structure):
+    """Structure used with ``GetStreamingLatestValues``."""
+
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("mode_", ctypes.c_int32),
+        ("type_", ctypes.c_int32),
+        ("noOfSamples_", ctypes.c_int32),
+        ("bufferIndex_", ctypes.c_uint64),
+        ("startIndex_", ctypes.c_int32),
+        ("overflow_", ctypes.c_int16),
+    ]
+
+
+class PICO_STREAMING_DATA_TRIGGER_INFO(ctypes.Structure):
+    """Trigger status information returned by ``GetStreamingLatestValues``."""
+
+    _fields_ = [
+        ("triggerAt_", ctypes.c_uint64),
+        ("triggered_", ctypes.c_int16),
+        ("autoStop_", ctypes.c_int16),
+    ]
+
+
 # General Functions
 def _check_path(location, folders):
     for folder in folders:
@@ -121,8 +146,15 @@ class PicoScopeBase:
         error_code = ERROR_STRING[status]
         if status != 0:
             if status in [POWER_SOURCE.SUPPLY_NOT_CONNECTED]:
-                warnings.warn('Power supply not connected.', 
-                              PowerSupplyWarning)
+                warnings.warn(
+                    'Power supply not connected.',
+                    PowerSupplyWarning,
+                )
+                return
+            # PICO_WAITING_FOR_DATA_BUFFERS (407) is not an error condition
+            # but indicates more buffers are required when streaming. Ignore
+            # it so that callers can continue processing the returned data.
+            if status == 407:
                 return
             self.close_unit()
             raise PicoSDKException(error_code)
@@ -690,6 +722,63 @@ class PicoScopeBase:
             None
         )
         return time_indisposed_ms.value
+
+    def run_streaming(
+        self,
+        sample_interval: float,
+        time_units: PICO_TIME_UNIT,
+        max_pre_trigger_samples: int,
+        max_post_trigger_samples: int,
+        auto_stop: bool = True,
+        down_sample_ratio: int = 1,
+        ratio_mode: RATIO_MODE = RATIO_MODE.RAW,
+    ) -> float:
+        """Start streaming mode acquisition and return the actual sample interval."""
+
+        c_interval = ctypes.c_double(sample_interval)
+        self._call_attr_function(
+            "RunStreaming",
+            self.handle,
+            ctypes.byref(c_interval),
+            time_units,
+            ctypes.c_uint64(max_pre_trigger_samples),
+            ctypes.c_uint64(max_post_trigger_samples),
+            int(auto_stop),
+            ctypes.c_uint64(down_sample_ratio),
+            ratio_mode,
+        )
+        return c_interval.value
+
+    def get_streaming_latest_values(
+        self,
+        streaming_data_info: list,
+        trigger_info: PICO_STREAMING_DATA_TRIGGER_INFO | None = None,
+    ) -> tuple[list, PICO_STREAMING_DATA_TRIGGER_INFO | None]:
+        """Retrieve the latest streaming data values."""
+
+        array_type = PICO_STREAMING_DATA_INFO * len(streaming_data_info)
+        info_array = array_type(*streaming_data_info)
+        trigger_ptr = ctypes.byref(trigger_info) if trigger_info is not None else None
+
+        self._call_attr_function(
+            "GetStreamingLatestValues",
+            self.handle,
+            info_array,
+            ctypes.c_uint64(len(streaming_data_info)),
+            trigger_ptr,
+        )
+        return list(info_array), trigger_info
+
+    def no_of_streaming_values(self) -> int:
+        """Return the number of values currently available while streaming."""
+
+        count = ctypes.c_uint64()
+        self._call_attr_function(
+            "NoOfStreamingValues",
+            self.handle,
+            ctypes.byref(count),
+        )
+        return count.value
     
     def get_enumerated_units(self) -> tuple[int, str, int]:
         """
@@ -1078,6 +1167,76 @@ class ps6000a(PicoScopeBase):
 
         # Generate the time axis based on actual samples and timebase
         time_axis = self.get_time_axis(timebase, actual_samples)
+
+        return channels_buffer, time_axis
+
+    def run_simple_streaming_capture(
+        self,
+        sample_interval: float,
+        time_units: PICO_TIME_UNIT,
+        samples: int,
+        pre_trig_percent: int = 0,
+        auto_stop: bool = True,
+        down_sample_ratio: int = 1,
+        ratio_mode: RATIO_MODE = RATIO_MODE.RAW,
+        datatype: DATA_TYPE = DATA_TYPE.INT16_T,
+    ) -> tuple[dict, list]:
+        """Convenience helper to perform a streaming capture."""
+
+        channels_buffer = self.set_data_buffer_for_enabled_channels(
+            samples, datatype=datatype, ratio_mode=ratio_mode
+        )
+
+        streaming_info = []
+        for ch in channels_buffer:
+            info = PICO_STREAMING_DATA_INFO()
+            info.channel_ = ch
+            info.mode_ = ratio_mode
+            info.type_ = datatype
+            info.noOfSamples_ = samples
+            info.bufferIndex_ = ctypes.addressof(channels_buffer[ch])
+            info.startIndex_ = 0
+            streaming_info.append(info)
+
+        pre = int(samples * pre_trig_percent / 100)
+        post = samples - pre
+
+        actual_interval = self.run_streaming(
+            sample_interval,
+            time_units,
+            pre,
+            post,
+            auto_stop,
+            down_sample_ratio,
+            ratio_mode,
+        )
+
+        trigger_info = PICO_STREAMING_DATA_TRIGGER_INFO()
+        collected = 0
+        while True:
+            infos, trigger_info = self.get_streaming_latest_values(
+                streaming_info, trigger_info
+            )
+            collected = max(
+                [i.startIndex_ + i.noOfSamples_ for i in infos] + [collected]
+            )
+            if trigger_info and trigger_info.autoStop_:
+                break
+            if collected >= samples:
+                break
+
+        channels_buffer = self.channels_buffer_adc_to_mv(channels_buffer)
+
+        unit_to_ns = {
+            PICO_TIME_UNIT.FS: 1e-6,
+            PICO_TIME_UNIT.PS: 1e-3,
+            PICO_TIME_UNIT.NS: 1,
+            PICO_TIME_UNIT.US: 1e3,
+            PICO_TIME_UNIT.MS: 1e6,
+            PICO_TIME_UNIT.S: 1e9,
+        }
+        interval_ns = actual_interval * unit_to_ns[time_units]
+        time_axis = [round(i * interval_ns, 4) for i in range(collected)]
 
         return channels_buffer, time_axis
     

--- a/tests/error_handler_test.py
+++ b/tests/error_handler_test.py
@@ -1,0 +1,8 @@
+import pytest
+from pypicosdk import ps6000a
+
+
+def test_waiting_for_data_buffers_is_ignored():
+    scope = ps6000a('pytest')
+    # should not raise for PICO_WAITING_FOR_DATA_BUFFERS
+    scope._error_handler(407)

--- a/tests/streaming_struct_test.py
+++ b/tests/streaming_struct_test.py
@@ -1,0 +1,30 @@
+import ctypes
+from pypicosdk import (
+    PICO_STREAMING_DATA_INFO,
+    PICO_STREAMING_DATA_TRIGGER_INFO,
+    CHANNEL,
+    DATA_TYPE,
+    RATIO_MODE,
+)
+
+def test_streaming_info_fields():
+    info = PICO_STREAMING_DATA_INFO()
+    info.channel_ = CHANNEL.A
+    info.mode_ = RATIO_MODE.RAW
+    info.type_ = DATA_TYPE.INT16_T
+    info.noOfSamples_ = 0
+    info.bufferIndex_ = 0
+    info.startIndex_ = 0
+    info.overflow_ = 0
+
+    assert info.channel_ == CHANNEL.A
+    assert info.mode_ == ctypes.c_int32(RATIO_MODE.RAW).value
+
+
+def test_streaming_trigger_info_fields():
+    trig = PICO_STREAMING_DATA_TRIGGER_INFO()
+    trig.triggerAt_ = 0
+    trig.triggered_ = 0
+    trig.autoStop_ = 0
+
+    assert trig.triggered_ == 0


### PR DESCRIPTION
## Summary
- expose new streaming structures
- add ps6000a streaming helpers and convenience capture
- document streaming support and add example
- note streaming support in roadmap
- basic tests for streaming structures
- handle PICO_WAITING_FOR_DATA_BUFFERS status in error handler
- fix streaming buffer setup

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474015c6ec8327a38026eb954a5a5f