### PR TITLE
Add streaming mode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ The output should be similar to:
 
 Once tested, try an [example script from github](https://github.com/StuLawPico/pyPicoSDK_Playground) to get started.
 
+### Streaming Quickstart
+The following snippet performs a basic streaming capture using `run_simple_streaming_capture`:
+```python
+import pypicosdk as psdk
+
+scope = psdk.ps6000a()
+scope.open_unit()
+scope.set_channel(psdk.CHANNEL.A, psdk.RANGE.V1)
+scope.set_simple_trigger(psdk.CHANNEL.A, threshold_mv=0)
+data, times = scope.run_simple_streaming_capture(1, psdk.PICO_TIME_UNIT.US, 1000)
+scope.close_unit()
+```
+
 ## Useful links and references
 - [Documentation & Reference](https://stulawpico.github.io/pyPicoSDK_Playground)
 - [GitHub Repo (with examples)](https://github.com/StuLawPico/pyPicoSDK_Playground)

--- a/docs/docs/dev/roadmap.md
+++ b/docs/docs/dev/roadmap.md
@@ -10,7 +10,6 @@
     - Current in [test pypi](https://test.pypi.org/project/pypicosdk/)
 
 ## To-Do
-- 6000 (A) streaming support
 - Add `run_simple_block_capture()` for 5000 (A)
 - Add support for 3000 (A) drivers
 - Test & add support for macOS & linux

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -37,6 +37,6 @@ Once tested, try an [example script from github](https://github.com/StuLawPico/p
 - [PicoScope Support (Compatibility)](https://stulawpico.github.io/pyPicoSDK_Playground/dev/current)
 
 ## Version Control
-pyPicoSDK: 0.2.30
+pyPicoSDK: 0.2.31
 
-Docs: 0.1.6
+Docs: 0.1.7

--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -18,3 +18,19 @@ scope.close_unit()
         - "!^_[^_]"
         show_root_toc_entry: false
         summary: true
+
+## Streaming Example
+```python
+import pypicosdk as psdk
+
+scope = psdk.ps6000a()
+scope.open_unit()
+scope.set_channel(psdk.CHANNEL.A, psdk.RANGE.V1)
+scope.set_simple_trigger(psdk.CHANNEL.A, threshold_mv=0)
+channel_buffer, time_axis = scope.run_simple_streaming_capture(
+    sample_interval=1,
+    sample_interval_time_units=psdk.PICO_TIME_UNIT.US,
+    samples=5000,
+)
+scope.close_unit()
+```

--- a/examples/example_6000a_simple_streaming.py
+++ b/examples/example_6000a_simple_streaming.py
@@ -1,0 +1,35 @@
+import pypicosdk as psdk
+from matplotlib import pyplot as plt
+
+# Setup variables
+sample_interval = 1
+sample_units = psdk.PICO_TIME_UNIT.US
+samples = 5000
+channel_a = psdk.CHANNEL.A
+range = psdk.RANGE.V1
+
+# Initialise PicoScope
+scope = psdk.ps6000a()
+scope.open_unit()
+
+# Setup channels and trigger
+scope.set_channel(channel=channel_a, range=range)
+scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
+
+# Run streaming capture
+channels, time_axis = scope.run_simple_streaming_capture(
+    sample_interval,
+    sample_units,
+    samples,
+)
+
+# Finish with PicoScope
+scope.close_unit()
+
+# Plot data to pyplot
+plt.plot(time_axis, channels[channel_a])
+plt.xlabel("Time (s)")
+plt.ylabel("Amplitude (mV)")
+plt.grid(True)
+plt.show()
+

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+import ctypes
 
 class UNIT_INFO:
     """
@@ -303,3 +304,27 @@ class DIGITAL_PORT_HYSTERESIS(IntEnum):
     HIGH_200MV = 1
     NORMAL_100MV = 2
     LOW_50MV = 3
+
+
+class PICO_STREAMING_DATA_INFO(ctypes.Structure):
+    """Structure describing streaming data buffer information."""
+
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("mode_", ctypes.c_int32),
+        ("type_", ctypes.c_int32),
+        ("noOfSamples_", ctypes.c_int32),
+        ("bufferIndex_", ctypes.c_uint64),
+        ("startIndex_", ctypes.c_int32),
+        ("overflow_", ctypes.c_int16),
+    ]
+
+
+class PICO_STREAMING_DATA_TRIGGER_INFO(ctypes.Structure):
+    """Structure describing trigger information for streaming."""
+
+    _fields_ = [
+        ("triggerAt_", ctypes.c_uint64),
+        ("triggered_", ctypes.c_int16),
+        ("autoStop_", ctypes.c_int16),
+    ]

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -2,6 +2,7 @@ import ctypes
 import os
 import warnings
 import platform
+import time
 
 from .error_list import ERROR_STRING
 from .constants import *
@@ -747,6 +748,58 @@ class PicoScopeBase:
         self.over_range = over_range.value
         self.is_over_range()
         return total_samples.value
+
+    def run_streaming(
+        self,
+        sample_interval: float,
+        sample_interval_time_units: PICO_TIME_UNIT,
+        max_pre_trigger_samples: int,
+        max_post_trigger_samples: int,
+        auto_stop: int = 1,
+        down_sample_ratio: int = 1,
+        down_sample_ratio_mode: int = RATIO_MODE.RAW,
+    ) -> float:
+        """Start streaming mode and return the actual sample interval."""
+
+        c_sample_interval = ctypes.c_double(sample_interval)
+        self._call_attr_function(
+            "RunStreaming",
+            self.handle,
+            ctypes.byref(c_sample_interval),
+            sample_interval_time_units,
+            ctypes.c_uint64(max_pre_trigger_samples),
+            ctypes.c_uint64(max_post_trigger_samples),
+            ctypes.c_int16(auto_stop),
+            ctypes.c_uint64(down_sample_ratio),
+            down_sample_ratio_mode,
+        )
+        return c_sample_interval.value
+
+    def get_streaming_latest_values(
+        self,
+        streaming_data_info,
+        trigger_info: PICO_STREAMING_DATA_TRIGGER_INFO,
+    ) -> None:
+        """Retrieve latest streaming values into provided buffers."""
+
+        self._call_attr_function(
+            "GetStreamingLatestValues",
+            self.handle,
+            streaming_data_info,
+            ctypes.c_uint64(len(streaming_data_info)),
+            ctypes.byref(trigger_info),
+        )
+
+    def no_of_streaming_values(self) -> int:
+        """Return number of samples available when streaming."""
+
+        values = ctypes.c_uint64()
+        self._call_attr_function(
+            "NoOfStreamingValues",
+            self.handle,
+            ctypes.byref(values),
+        )
+        return values.value
     
     def is_over_range(self) -> list:
         """
@@ -1036,7 +1089,7 @@ class ps6000a(PicoScopeBase):
         self._siggen_set_duty_cycle(duty)
         return self._siggen_apply()
     
-    def run_simple_block_capture(self, timebase:int, samples:int, segment=0, start_index=0, datatype=DATA_TYPE.INT16_T, ratio=0, 
+    def run_simple_block_capture(self, timebase:int, samples:int, segment=0, start_index=0, datatype=DATA_TYPE.INT16_T, ratio=0,
                          ratio_mode=RATIO_MODE.RAW, pre_trig_percent=50) -> tuple[dict, list]:
         """
         Performs a complete single block capture using current channel and trigger configuration.
@@ -1078,6 +1131,70 @@ class ps6000a(PicoScopeBase):
 
         # Generate the time axis based on actual samples and timebase
         time_axis = self.get_time_axis(timebase, actual_samples)
+
+        return channels_buffer, time_axis
+
+    def run_simple_streaming_capture(
+        self,
+        sample_interval: float,
+        sample_interval_time_units: PICO_TIME_UNIT,
+        samples: int,
+        auto_stop: bool = True,
+        datatype: DATA_TYPE = DATA_TYPE.INT16_T,
+        ratio_mode: int = RATIO_MODE.RAW,
+    ) -> tuple[dict, list]:
+        """Perform a simple streaming capture and return buffers and time axis."""
+
+        channels_buffer = self.set_data_buffer_for_enabled_channels(samples, 0, datatype, ratio_mode)
+
+        actual_interval = self.run_streaming(
+            sample_interval,
+            sample_interval_time_units,
+            0,
+            samples,
+            int(auto_stop),
+            1,
+            ratio_mode,
+        )
+
+        collected = 0
+        trigger_info = PICO_STREAMING_DATA_TRIGGER_INFO()
+
+        while collected < samples:
+            available = self.no_of_streaming_values()
+            if available <= collected:
+                time.sleep(0.01)
+                continue
+
+            to_read = available - collected
+            data_array = (PICO_STREAMING_DATA_INFO * len(channels_buffer))()
+            for idx, ch in enumerate(channels_buffer):
+                data_array[idx].channel_ = ch
+                data_array[idx].mode_ = ratio_mode
+                data_array[idx].type_ = datatype
+                data_array[idx].noOfSamples_ = to_read
+                data_array[idx].bufferIndex_ = collected
+                data_array[idx].startIndex_ = collected
+                data_array[idx].overflow_ = 0
+
+            self.get_streaming_latest_values(data_array, trigger_info)
+            collected += data_array[0].noOfSamples_
+
+            if auto_stop and trigger_info.autoStop_:
+                break
+
+        channels_buffer = self.channels_buffer_adc_to_mv(channels_buffer)
+
+        seconds_per_sample = {
+            PICO_TIME_UNIT.FS: 1e-15,
+            PICO_TIME_UNIT.PS: 1e-12,
+            PICO_TIME_UNIT.NS: 1e-9,
+            PICO_TIME_UNIT.US: 1e-6,
+            PICO_TIME_UNIT.MS: 1e-3,
+            PICO_TIME_UNIT.S: 1,
+        }[sample_interval_time_units] * actual_interval
+
+        time_axis = [n * seconds_per_sample for n in range(collected)]
 
         return channels_buffer, time_axis
     

--- a/tests/streaming_test.py
+++ b/tests/streaming_test.py
@@ -1,0 +1,38 @@
+from pypicosdk import ps6000a, PICO_TIME_UNIT, RATIO_MODE, DATA_TYPE, PICO_STREAMING_DATA_INFO, PICO_STREAMING_DATA_TRIGGER_INFO
+
+def test_run_streaming_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+    scope._call_attr_function = fake_call
+    scope.run_streaming(1.0, PICO_TIME_UNIT.US, 0, 100, 1, 1, RATIO_MODE.RAW)
+    assert called['name'] == 'RunStreaming'
+
+
+def test_get_streaming_latest_values_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+    scope._call_attr_function = fake_call
+    info = (PICO_STREAMING_DATA_INFO * 1)()
+    trig = PICO_STREAMING_DATA_TRIGGER_INFO()
+    scope.get_streaming_latest_values(info, trig)
+    assert called['name'] == 'GetStreamingLatestValues'
+
+
+def test_no_of_streaming_values_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+    def fake_call(name, *args):
+        called['name'] = name
+        return 0
+    scope._call_attr_function = fake_call
+    scope.no_of_streaming_values()
+    assert called['name'] == 'NoOfStreamingValues'
+

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
 # Master version file for all scripts.
 # Update these variables and run a build-tool (which will run version_updater.py)
-docs_version = "0.1.6"
-package_version = "0.2.30"
+docs_version = "0.1.7"
+package_version = "0.2.31"


### PR DESCRIPTION
## Summary
- add streaming usage example to README
- document streaming in ps6000a reference
- implement streaming data structures and API wrappers
- provide `run_simple_streaming_capture` helper
- add streaming example script and tests
- bump package and docs versions

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474dd681288327bacba54b23a1d7eb