### PR TITLE
Fix streaming example error handling

### DIFF
--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -122,8 +122,13 @@ class PicoScopeBase:
         error_code = ERROR_STRING[status]
         if status != 0:
             if status in [POWER_SOURCE.SUPPLY_NOT_CONNECTED]:
-                warnings.warn('Power supply not connected.', 
+                warnings.warn('Power supply not connected.',
                               PowerSupplyWarning)
+                return
+            # Certain status codes indicate that the driver is busy or waiting
+            # for more data rather than an actual failure. These should not
+            # raise an exception as callers may poll until data is ready.
+            if status == 407:  # PICO_WAITING_FOR_DATA_BUFFERS
                 return
             self.close_unit()
             raise PicoSDKException(error_code)


### PR DESCRIPTION
## Summary
- avoid raising exceptions while waiting for streaming data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684756ecc26883279a51de43f9e9a56b