### PR TITLE
Fix streaming example assignment

### DIFF
--- a/examples/example_6000a_continuous_streaming.py
+++ b/examples/example_6000a_continuous_streaming.py
@@ -61,7 +61,7 @@ trigger_info = psdk.PICO_STREAMING_DATA_TRIGGER_INFO()
 try:
     while True:
         data_array = (psdk.PICO_STREAMING_DATA_INFO * 1)()
-        data_array[0].channel_ = channels_buffer[channel_a]
+        data_array[0].channel_ = channel_a
         data_array[0].mode_ = psdk.RATIO_MODE.RAW
         data_array[0].type_ = psdk.DATA_TYPE.INT16_T
         data_array[0].noOfSamples_ = chunk_samples


### PR DESCRIPTION
## Summary
- fix `channel_` field assignment in `example_6000a_continuous_streaming.py`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68475a95e8d083279d97a632ca7090d3