### PR TITLE
Fix streaming buffer recycling

### DIFF
--- a/examples/example_6000a_continuous_streaming.py
+++ b/examples/example_6000a_continuous_streaming.py
@@ -21,7 +21,7 @@ scope.open_unit()
 scope.set_channel(channel=channel_a, range=voltage_range)
 scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
 
-# Allocate buffers for streaming
+# Allocate initial buffer for streaming (re-added after each read)
 channels_buffer = scope.set_data_buffer_for_enabled_channels(chunk_samples)
 
 # Start streaming with FIFO up to 4G samples
@@ -77,6 +77,10 @@ def streaming_worker() -> None:
                 for sample in channels_buffer[channel_a][:num]
             ]
             data_queue.put(mv)
+            # Re-register buffer for next chunk
+            channels_buffer[channel_a] = scope.set_data_buffer(
+                channel_a, chunk_samples, action=psdk.ACTION.ADD
+            )
 
 
 worker = threading.Thread(target=streaming_worker, daemon=True)


### PR DESCRIPTION
## Summary
- fix continuous streaming example by reassigning buffers after reads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d23e7c7c832796c2dab50eefb8ee