### PR TITLE
Ignore streaming reread status codes

### DIFF
--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -130,6 +130,11 @@ class PicoScopeBase:
             # raise an exception as callers may poll until data is ready.
             if status == 407:  # PICO_WAITING_FOR_DATA_BUFFERS
                 return
+            # Streaming related status codes indicate no new data is ready.
+            # These should not be treated as fatal errors and simply signal
+            # the caller to try again later.
+            if status in [28672, 28673, 28674]:
+                return
             self.close_unit()
             raise PicoSDKException(error_code)
         return


### PR DESCRIPTION
## Summary
- treat streaming status codes as non fatal so continuous streaming demo doesn't crash

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e983efb483279d90889d421191fd