### PR TITLE
Improve responsiveness of streaming plot

### DIFF
--- a/examples/example_6000a_continuous_streaming.py
+++ b/examples/example_6000a_continuous_streaming.py
@@ -114,6 +114,7 @@ worker.start()
 plt.ion()
 fig, ax = plt.subplots()
 (line,) = ax.plot([], [])
+plt.show(block=False)
 ax.set_xlabel("Time (s)")
 ax.set_ylabel("Amplitude (mV)")
 ax.grid(True)
@@ -129,6 +130,7 @@ try:
         try:
             data_chunk = data_queue.get(timeout=0.1)
         except Empty:
+            plt.pause(0.001)
             continue
 
         for sample in data_chunk:


### PR DESCRIPTION
## Summary
- call `plt.show(block=False)` to ensure the plot window is shown
- pause the GUI event loop even when no data is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f61e73e88327908ca40483c5f07b