### PR TITLE
Fix interactive streaming plot backend

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -38,4 +38,6 @@ scope.close_unit()
 ## Continuous Streaming Example
 A longer example that continuously plots incoming data while streaming is available in
 `examples/example_6000a_continuous_streaming.py`. The plot updates in real time and
-maintains a rolling window controlled by `plot_samples`.
+maintains a rolling window controlled by `plot_samples`. If the plot window does not
+update, check the Matplotlib backend being used. Interactive backends such as
+`TkAgg` or `Qt5Agg` are required for live updates.

--- a/examples/example_6000a_continuous_streaming.py
+++ b/examples/example_6000a_continuous_streaming.py
@@ -8,6 +8,12 @@ signal generator with a simple sine wave so data appears on-screen.
 import logging
 import tracemalloc
 
+import matplotlib
+backend = matplotlib.get_backend()
+print(f"Matplotlib backend: {backend}")
+if backend not in matplotlib.rcsetup.interactive_bk:
+    matplotlib.use("TkAgg")
+
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 from collections import deque


### PR DESCRIPTION
## Summary
- ensure the continuous streaming example chooses an interactive matplotlib backend
- document interactive backend requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847fefe71fc8327a4f7c5a6a80abce1