### PR TITLE
Expand simple streaming example with optional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,14 @@ scope = psdk.ps6000a()
 scope.open_unit()
 scope.set_channel(psdk.CHANNEL.A, psdk.RANGE.V1)
 scope.set_simple_trigger(psdk.CHANNEL.A, threshold_mv=0)
-data, times = scope.run_simple_streaming_capture(1, psdk.PICO_TIME_UNIT.US, 1000)
+data, times = scope.run_simple_streaming_capture(
+    sample_interval=1,
+    sample_interval_time_units=psdk.PICO_TIME_UNIT.US,
+    samples=1000,
+    auto_stop=True,
+    datatype=psdk.DATA_TYPE.INT16_T,
+    ratio_mode=psdk.RATIO_MODE.RAW,
+)
 scope.close_unit()
 ```
 

--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -31,6 +31,9 @@ channel_buffer, time_axis = scope.run_simple_streaming_capture(
     sample_interval=1,
     sample_interval_time_units=psdk.PICO_TIME_UNIT.US,
     samples=5000,
+    auto_stop=True,
+    datatype=psdk.DATA_TYPE.INT16_T,
+    ratio_mode=psdk.RATIO_MODE.RAW,
 )
 scope.close_unit()
 ```

--- a/examples/example_6000a_simple_streaming.py
+++ b/examples/example_6000a_simple_streaming.py
@@ -18,9 +18,12 @@ scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
 
 # Run streaming capture
 channels, time_axis = scope.run_simple_streaming_capture(
-    sample_interval,
-    sample_units,
-    samples,
+    sample_interval=sample_interval,
+    sample_interval_time_units=sample_units,
+    samples=samples,
+    auto_stop=True,
+    datatype=psdk.DATA_TYPE.INT16_T,
+    ratio_mode=psdk.RATIO_MODE.RAW,
 )
 
 # Finish with PicoScope

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -1153,8 +1153,19 @@ class ps6000a(PicoScopeBase):
         datatype: DATA_TYPE = DATA_TYPE.INT16_T,
         ratio_mode: int = RATIO_MODE.RAW,
     ) -> tuple[dict, list]:
-        """Perform a simple streaming capture and return buffers and time axis."""
+        """Perform a simple streaming capture and return buffers and time axis.
 
+        Args:
+            sample_interval (float): Desired sample interval.
+            sample_interval_time_units (PICO_TIME_UNIT): Units for ``sample_interval``.
+            samples (int): Number of samples to capture.
+            auto_stop (bool, optional): Stop automatically once ``samples`` have been collected.
+            datatype (DATA_TYPE, optional): Data type used for the capture buffer.
+            ratio_mode (RATIO_MODE, optional): Downsampling mode.
+
+        Returns:
+            tuple[dict, list]: Dictionary of channel buffers (in mV) and the time axis in seconds.
+        """
         channels_buffer = self.set_data_buffer_for_enabled_channels(samples, 0, datatype, ratio_mode)
 
         actual_interval = self.run_streaming(


### PR DESCRIPTION
## Summary
- expand `run_simple_streaming_capture` docstring with argument details
- use all optional parameters in the simple streaming example
- update README and reference docs to match

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684808627e548327a83d88cf74b15414