### PR TITLE
Fix NotImplementedError message in pypicosdk.py

### DIFF
--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -859,7 +859,7 @@ class PicoScopeBase:
         
     
     def run_simple_block_capture(self) -> dict:
-        raise NotImplementedError("This method is not yet implimented in this PicoScope")
+        raise NotImplementedError("This method is not yet implemented in this PicoScope")
     
     # Siggen Functions
     def _siggen_apply(self, enabled=1, sweep_enabled=0, trigger_enabled=0, 


### PR DESCRIPTION
## Summary
- fix typo in NotImplementedError message in pypicosdk.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482df2bcdc8327b06be9eed0d5481d