### PR TITLE
Implement get_trigger_info

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -328,3 +328,17 @@ class PICO_STREAMING_DATA_TRIGGER_INFO(ctypes.Structure):
         ("triggered_", ctypes.c_int16),
         ("autoStop_", ctypes.c_int16),
     ]
+
+
+class PICO_TRIGGER_INFO(ctypes.Structure):
+    """Structure describing trigger timing information."""
+
+    _fields_ = [
+        ("status_", ctypes.c_int32),
+        ("segmentIndex_", ctypes.c_uint64),
+        ("triggerIndex_", ctypes.c_uint64),
+        ("triggerTime_", ctypes.c_double),
+        ("timeUnits_", ctypes.c_int32),
+        ("missedTriggers_", ctypes.c_uint64),
+        ("timeStampCounter_", ctypes.c_uint64),
+    ]

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -470,26 +470,34 @@ class PicoScopeBase:
         return time.value
 
 
-    def get_trigger_info(self, segment_index: int = 0) -> int:
-        """Retrieve trigger timing information.
+    def get_trigger_info(
+        self,
+        trigger_info,
+        first_segment_index: int = 0,
+        segment_count: int = 1,
+    ) -> None:
+        """Retrieve trigger timing information for one or more segments.
 
         Args:
-            segment_index (int, optional): The memory segment to query. Defaults to 0.
-
-        Returns:
-            int: Raw trigger information returned by the driver.
+            trigger_info: Array of :class:`PICO_TRIGGER_INFO` structures that will
+                be populated by the driver.
+            first_segment_index (int, optional): Index of the first segment to
+                query. Defaults to ``0``.
+            segment_count (int, optional): Number of segments to query. Defaults
+                to ``1``.
 
         Raises:
-            PicoSDKException: If the function call fails or preconditions are not met.
+            PicoSDKException: If the function call fails or preconditions are not
+                met.
         """
-        info = ctypes.c_uint64()
+
         self._call_attr_function(
-            'GetTriggerInfo',
+            "GetTriggerInfo",
             self.handle,
-            ctypes.byref(info),
-            segment_index
+            trigger_info,
+            ctypes.c_uint64(first_segment_index),
+            ctypes.c_uint64(segment_count),
         )
-        return info.value
 
 
     

--- a/tests/trigger_info_test.py
+++ b/tests/trigger_info_test.py
@@ -1,0 +1,16 @@
+from pypicosdk import ps6000a, PICO_TRIGGER_INFO
+
+
+def test_get_trigger_info_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    info = (PICO_TRIGGER_INFO * 1)()
+    scope.get_trigger_info(info, 0, 1)
+    assert called['name'] == 'GetTriggerInfo'


### PR DESCRIPTION
## Summary
- add `PICO_TRIGGER_INFO` structure for trigger metadata
- rework `get_trigger_info` to accept struct array and segment arguments
- test invocation of `get_trigger_info`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685161e166d08327852237b05b03181a