### PR TITLE
Improve ps6000a trigger info

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -331,7 +331,24 @@ class PICO_STREAMING_DATA_TRIGGER_INFO(ctypes.Structure):
 
 
 class PICO_TRIGGER_INFO(ctypes.Structure):
-    """Structure describing trigger timing information."""
+    """Structure describing trigger timing information.
+
+    Attributes:
+        status_:   :class:`PICO_STATUS` value describing the trigger state. This
+            may be a bitwise OR of multiple status flags such as
+            ``PICO_DEVICE_TIME_STAMP_RESET`` or
+            ``PICO_TRIGGER_TIME_NOT_REQUESTED``.
+        segmentIndex_:  Memory segment index from which the information was
+            captured.
+        triggerIndex_:  Sample index at which the trigger occurred.
+        triggerTime_:   Time of the trigger event calculated with sub-sample
+            resolution.
+        timeUnits_:     Units for ``triggerTime_`` as a
+            :class:`PICO_TIME_UNIT` value.
+        missedTriggers_: Number of trigger events that occurred between this
+            capture and the previous one.
+        timeStampCounter_:  Timestamp in samples from the first capture.
+    """
 
     _fields_ = [
         ("status_", ctypes.c_int32),

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -3,6 +3,7 @@ import os
 import warnings
 import platform
 import time
+import typing
 
 from .error_list import ERROR_STRING
 from .constants import *
@@ -472,32 +473,38 @@ class PicoScopeBase:
 
     def get_trigger_info(
         self,
-        trigger_info,
         first_segment_index: int = 0,
         segment_count: int = 1,
-    ) -> None:
+    ) -> typing.Union[PICO_TRIGGER_INFO, list[PICO_TRIGGER_INFO]]:
         """Retrieve trigger timing information for one or more segments.
 
         Args:
-            trigger_info: Array of :class:`PICO_TRIGGER_INFO` structures that will
-                be populated by the driver.
-            first_segment_index (int, optional): Index of the first segment to
-                query. Defaults to ``0``.
-            segment_count (int, optional): Number of segments to query. Defaults
-                to ``1``.
+            first_segment_index: Index of the first memory segment to query.
+            segment_count: Number of segments to query starting from
+                ``first_segment_index``.
+
+        Returns:
+            :class:`PICO_TRIGGER_INFO` if ``segment_count`` is ``1`` otherwise a
+            list of ``PICO_TRIGGER_INFO`` objects.
 
         Raises:
             PicoSDKException: If the function call fails or preconditions are not
                 met.
         """
 
+        info_array = (PICO_TRIGGER_INFO * segment_count)()
+
         self._call_attr_function(
             "GetTriggerInfo",
             self.handle,
-            trigger_info,
+            ctypes.byref(info_array[0]),
             ctypes.c_uint64(first_segment_index),
             ctypes.c_uint64(segment_count),
         )
+
+        if segment_count == 1:
+            return info_array[0]
+        return list(info_array)
 
 
     

--- a/tests/trigger_info_test.py
+++ b/tests/trigger_info_test.py
@@ -11,6 +11,5 @@ def test_get_trigger_info_invocation():
         return 0
 
     scope._call_attr_function = fake_call
-    info = (PICO_TRIGGER_INFO * 1)()
-    scope.get_trigger_info(info, 0, 1)
+    info = scope.get_trigger_info(0, 1)
     assert called['name'] == 'GetTriggerInfo'


### PR DESCRIPTION
## Summary
- document `PICO_TRIGGER_INFO` fields
- refactor `get_trigger_info` to allocate structs internally
- return trigger info structures from `get_trigger_info`
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851697561b88327943d5fe396deaf8d