### PR TITLE
Improve trigger struct docs

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,6 +29,12 @@ The output should be similar to:
 
 Once tested, try an [example script from github](https://github.com/StuLawPico/pyPicoSDK_Playground) to get started.
 
+### Struct field names
+Many functions return data using ``ctypes`` structures. The attributes of
+these structures include a trailing underscore in their names. Use the
+exact names shown in the API when accessing these values; for example
+``info.triggerTime_``.
+
 ## Useful links and references
 - [Documentation & Reference](https://stulawpico.github.io/pyPicoSDK_Playground)
 - [GitHub Repo (with examples)](https://github.com/StuLawPico/pyPicoSDK_Playground)

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -321,7 +321,13 @@ class PICO_STREAMING_DATA_INFO(ctypes.Structure):
 
 
 class PICO_STREAMING_DATA_TRIGGER_INFO(ctypes.Structure):
-    """Structure describing trigger information for streaming."""
+    """Structure describing trigger information for streaming.
+
+    All field names in this structure are defined with a trailing
+    underscore. These exact names must be used when accessing the
+    attributes returned by functions such as
+    :meth:`~pypicosdk.pypicosdk.PicoScopeBase.get_streaming_latest_values`.
+    """
 
     _fields_ = [
         ("triggerAt_", ctypes.c_uint64),
@@ -332,6 +338,12 @@ class PICO_STREAMING_DATA_TRIGGER_INFO(ctypes.Structure):
 
 class PICO_TRIGGER_INFO(ctypes.Structure):
     """Structure describing trigger timing information.
+
+    All fields of this ``ctypes`` structure include a trailing underscore in
+    their names. When you receive a :class:`PICO_TRIGGER_INFO` instance from
+    :meth:`~pypicosdk.pypicosdk.PicoScopeBase.get_trigger_info` or other
+    functions, access the attributes using these exact names, for example
+    ``info.triggerTime_``.
 
     Attributes:
         status_:   :class:`PICO_STATUS` value describing the trigger state. This

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -478,6 +478,10 @@ class PicoScopeBase:
     ) -> typing.Union[PICO_TRIGGER_INFO, list[PICO_TRIGGER_INFO]]:
         """Retrieve trigger timing information for one or more segments.
 
+        The returned :class:`PICO_TRIGGER_INFO` objects expose their fields
+        with names that end in an underscore. When reading values from the
+        structure you must use these names, for example ``info.triggerTime_``.
+
         Args:
             first_segment_index: Index of the first memory segment to query.
             segment_count: Number of segments to query starting from


### PR DESCRIPTION
## Summary
- document trailing underscore fields for `PICO_STREAMING_DATA_TRIGGER_INFO`
- document trailing underscore fields for `PICO_TRIGGER_INFO`
- clarify attribute naming in `get_trigger_info`
- add note about struct field names in docs index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851784356f8832788b931cb3875a206