### PR TITLE
Add AUX trigger support

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -110,8 +110,7 @@ class WAVEFORM:
     ARBITRARY = 0x10000000
 
 class CHANNEL(IntEnum):
-    """
-    Constants for each channel of the PicoScope.
+    """Constants representing PicoScope trigger and input channels.
 
     Attributes:
         A: Channel A
@@ -122,6 +121,7 @@ class CHANNEL(IntEnum):
         F: Channel F
         G: Channel G
         H: Channel H
+        TRIGGER_AUX: Dedicated auxiliary trigger input
     """
     A = 0
     B = 1
@@ -129,8 +129,9 @@ class CHANNEL(IntEnum):
     D = 3
     E = 4
     F = 5
-    G = 6 
+    G = 6
     H = 7
+    TRIGGER_AUX = 1001
 
 
 CHANNEL_NAMES = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
@@ -304,6 +305,14 @@ class DIGITAL_PORT_HYSTERESIS(IntEnum):
     HIGH_200MV = 1
     NORMAL_100MV = 2
     LOW_50MV = 3
+
+
+class AUXIO_MODE(IntEnum):
+    """Operating modes for the AUX IO connector."""
+    INPUT = 0
+    HIGH_OUT = 1
+    LOW_OUT = 2
+    TRIGGER_OUT = 3
 
 
 class PICO_STREAMING_DATA_INFO(ctypes.Structure):

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -622,7 +622,10 @@ class PicoScopeBase:
             delay (int, optional): Delay in samples after the trigger condition is met before starting capture. 
             auto_trigger (int, optional): Timeout after which data capture proceeds even if no trigger occurs. 
         """
-        threshold_adc = self.mv_to_adc(threshold_mv, self.range[channel])
+        if channel in self.range:
+            threshold_adc = self.mv_to_adc(threshold_mv, self.range[channel])
+        else:
+            threshold_adc = int(threshold_mv)
         self._call_attr_function(
             'SetSimpleTrigger',
             self.handle,
@@ -1075,6 +1078,15 @@ class ps6000a(PicoScopeBase):
             "SetDigitalPortOff",
             self.handle,
             port,
+        )
+
+    def set_aux_io_mode(self, mode: AUXIO_MODE) -> None:
+        """Configure the AUX IO connector using ``ps6000aSetAuxIoMode``."""
+
+        self._call_attr_function(
+            "SetAuxIoMode",
+            self.handle,
+            mode,
         )
 
     def set_simple_trigger(self, channel, threshold_mv, enable=True, direction=TRIGGER_DIR.RISING, delay=0, auto_trigger_ms=5_000):

--- a/tests/aux_io_test.py
+++ b/tests/aux_io_test.py
@@ -1,0 +1,15 @@
+from pypicosdk import ps6000a, AUXIO_MODE
+
+
+def test_set_aux_io_mode_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.set_aux_io_mode(AUXIO_MODE.INPUT)
+    assert called['name'] == 'SetAuxIoMode'


### PR DESCRIPTION
## Summary
- expose AUX trigger channel and AUXIO modes
- wrap `ps6000aSetAuxIoMode`
- allow `set_simple_trigger` to work with AUX input
- test AUX IO wrapper

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a41ddbc48327b998df3a138f864d