### PR TITLE
Improve get_trigger_info documentation

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -110,8 +110,7 @@ class WAVEFORM:
     ARBITRARY = 0x10000000
 
 class CHANNEL(IntEnum):
-    """
-    Constants for each channel of the PicoScope.
+    """Constants representing PicoScope trigger and input channels.
 
     Attributes:
         A: Channel A
@@ -122,6 +121,7 @@ class CHANNEL(IntEnum):
         F: Channel F
         G: Channel G
         H: Channel H
+        TRIGGER_AUX: Dedicated auxiliary trigger input
     """
     A = 0
     B = 1
@@ -312,8 +312,8 @@ class DIGITAL_PORT_HYSTERESIS(IntEnum):
     LOW_50MV = 3
 
 
-class PICO_AUXIO_MODE(IntEnum):
-    """Modes for the AUX port input/output."""
+class AUXIO_MODE(IntEnum):
+    """Operating modes for the AUX IO connector."""
 
     #: High impedance input for triggering the scope or signal generator.
     INPUT = 0

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -132,6 +132,12 @@ class CHANNEL(IntEnum):
     G = 6 
     H = 7
 
+    #: External trigger input.
+    EXTERNAL = 1000
+
+    #: Auxiliary trigger input/output.
+    TRIGGER_AUX = 1001
+
 
 CHANNEL_NAMES = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
 
@@ -304,6 +310,22 @@ class DIGITAL_PORT_HYSTERESIS(IntEnum):
     HIGH_200MV = 1
     NORMAL_100MV = 2
     LOW_50MV = 3
+
+
+class PICO_AUXIO_MODE(IntEnum):
+    """Modes for the AUX port input/output."""
+
+    #: High impedance input for triggering the scope or signal generator.
+    INPUT = 0
+
+    #: Constant logic high output.
+    HIGH_OUT = 1
+
+    #: Constant logic low output.
+    LOW_OUT = 2
+
+    #: Logic high pulse during the post-trigger acquisition time.
+    TRIGGER_OUT = 3
 
 
 class PICO_STREAMING_DATA_INFO(ctypes.Structure):

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -478,22 +478,29 @@ class PicoScopeBase:
     ) -> typing.Union[PICO_TRIGGER_INFO, list[PICO_TRIGGER_INFO]]:
         """Retrieve trigger timing information for one or more segments.
 
-        The returned :class:`PICO_TRIGGER_INFO` objects expose their fields
-        with names that end in an underscore. When reading values from the
-        structure you must use these names, for example ``info.triggerTime_``.
+        This method wraps the ``ps6000aGetTriggerInfo`` API call and returns
+        one or more :class:`~pypicosdk.constants.PICO_TRIGGER_INFO` structures.
+        Each structure exposes attributes such as ``status_``, ``triggerTime_``
+        and ``timeUnits_`` (refer to :mod:`pypicosdk.constants` for the full
+        list of fields).  The ``status_`` field is a
+        :class:`~pypicosdk.constants.PICO_STATUS` bit field that may include
+        flags like ``PICO_DEVICE_TIME_STAMP_RESET`` or
+        ``PICO_TRIGGER_TIME_NOT_REQUESTED``. ``timeUnits_`` values are defined
+        by :class:`~pypicosdk.constants.PICO_TIME_UNIT`.
 
         Args:
             first_segment_index: Index of the first memory segment to query.
-            segment_count: Number of segments to query starting from
+            segment_count: Number of consecutive segments starting at
                 ``first_segment_index``.
 
         Returns:
-            :class:`PICO_TRIGGER_INFO` if ``segment_count`` is ``1`` otherwise a
-            list of ``PICO_TRIGGER_INFO`` objects.
+            If ``segment_count`` is ``1``, a single ``PICO_TRIGGER_INFO``
+            instance is returned. Otherwise a list of ``PICO_TRIGGER_INFO``
+            objects is provided.
 
         Raises:
-            PicoSDKException: If the function call fails or preconditions are not
-                met.
+            PicoSDKException: If the function call fails or preconditions are
+                not met.
         """
 
         info_array = (PICO_TRIGGER_INFO * segment_count)()
@@ -1068,6 +1075,19 @@ class ps6000a(PicoScopeBase):
             "SetDigitalPortOff",
             self.handle,
             port,
+        )
+
+    def set_aux_io_mode(self, mode: PICO_AUXIO_MODE) -> None:
+        """Configure the AUX port using ``ps6000aSetAuxIoMode``.
+
+        Args:
+            mode: Requested AUXIO mode from :class:`~pypicosdk.constants.PICO_AUXIO_MODE`.
+        """
+
+        self._call_attr_function(
+            "SetAuxIoMode",
+            self.handle,
+            mode,
         )
 
     def set_simple_trigger(self, channel, threshold_mv, enable=True, direction=TRIGGER_DIR.RISING, delay=0, auto_trigger_ms=5_000):

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -622,7 +622,10 @@ class PicoScopeBase:
             delay (int, optional): Delay in samples after the trigger condition is met before starting capture. 
             auto_trigger (int, optional): Timeout after which data capture proceeds even if no trigger occurs. 
         """
-        threshold_adc = self.mv_to_adc(threshold_mv, self.range[channel])
+        if channel in self.range:
+            threshold_adc = self.mv_to_adc(threshold_mv, self.range[channel])
+        else:
+            threshold_adc = int(threshold_mv)
         self._call_attr_function(
             'SetSimpleTrigger',
             self.handle,
@@ -1077,11 +1080,11 @@ class ps6000a(PicoScopeBase):
             port,
         )
 
-    def set_aux_io_mode(self, mode: PICO_AUXIO_MODE) -> None:
-        """Configure the AUX port using ``ps6000aSetAuxIoMode``.
+    def set_aux_io_mode(self, mode: AUXIO_MODE) -> None:
+        """Configure the AUX IO connector using ``ps6000aSetAuxIoMode``.
 
         Args:
-            mode: Requested AUXIO mode from :class:`~pypicosdk.constants.PICO_AUXIO_MODE`.
+            mode: Requested AUXIO mode from :class:`~pypicosdk.constants.AUXIO_MODE`.
         """
 
         self._call_attr_function(

--- a/tests/aux_io_test.py
+++ b/tests/aux_io_test.py
@@ -1,0 +1,15 @@
+from pypicosdk import ps6000a, AUXIO_MODE
+
+
+def test_set_aux_io_mode_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.set_aux_io_mode(AUXIO_MODE.INPUT)
+    assert called['name'] == 'SetAuxIoMode'


### PR DESCRIPTION
## Summary
- document `get_trigger_info` more thoroughly
- add enumeration entries for `EXTERNAL` and `TRIGGER_AUX`
- expose AUXIO mode constants and wrapper method

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852924ac9648327860d69421b6d822c