### PR TITLE
Remove duplicate TRIGGER_AUX enum

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -131,7 +131,6 @@ class CHANNEL(IntEnum):
     F = 5
     G = 6
     H = 7
-    TRIGGER_AUX = 1001
 
     #: External trigger input.
     EXTERNAL = 1000


### PR DESCRIPTION
## Summary
- fix `TRIGGER_AUX` being defined twice in `CHANNEL`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545f5c82f48327a6ebb64e654a39c8