### PR TITLE
Implement PICO_CONDITION wrapper

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -328,6 +328,19 @@ class AUXIO_MODE(IntEnum):
     TRIGGER_OUT = 3
 
 
+class PICO_TRIGGER_STATE(IntEnum):
+    """Trigger state values used in :class:`PICO_CONDITION`."""
+
+    #: Channel is ignored when evaluating trigger conditions.
+    DONT_CARE = 0
+
+    #: Condition must be true for the channel.
+    TRUE = 1
+
+    #: Condition must be false for the channel.
+    FALSE = 2
+
+
 class PICO_STREAMING_DATA_INFO(ctypes.Structure):
     """Structure describing streaming data buffer information."""
 
@@ -392,4 +405,17 @@ class PICO_TRIGGER_INFO(ctypes.Structure):
         ("timeUnits_", ctypes.c_int32),
         ("missedTriggers_", ctypes.c_uint64),
         ("timeStampCounter_", ctypes.c_uint64),
+    ]
+
+
+class PICO_CONDITION(ctypes.Structure):
+    """Trigger condition structure used by ``SetTriggerChannelConditions``.
+
+    Each instance defines the state that a particular input source must meet
+    for the overall trigger to occur.
+    """
+
+    _fields_ = [
+        ("source_", ctypes.c_int32),
+        ("condition_", ctypes.c_int32),
     ]

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -636,6 +636,36 @@ class PicoScopeBase:
             delay,
             auto_trigger
         )
+
+    def set_trigger_channel_conditions(
+        self,
+        conditions: typing.Sequence[PICO_CONDITION],
+        action: int = ACTION.CLEAR_ALL | ACTION.ADD,
+    ) -> None:
+        """Configure complex triggering logic using ``SetTriggerChannelConditions``.
+
+        Args:
+            conditions: Sequence of :class:`~pypicosdk.constants.PICO_CONDITION`
+                structures defining the trigger logic. An empty sequence
+                disables triggering.
+            action: How to apply the provided conditions relative to any
+                existing conditions. Defaults to ``ACTION.CLEAR_ALL | ACTION.ADD``.
+        """
+
+        n_conditions = len(conditions)
+        if n_conditions:
+            cond_array = (PICO_CONDITION * n_conditions)(*conditions)
+            cond_ptr = cond_array
+        else:
+            cond_ptr = None
+
+        self._call_attr_function(
+            "SetTriggerChannelConditions",
+            self.handle,
+            cond_ptr,
+            ctypes.c_int16(n_conditions),
+            action,
+        )
     
     def set_data_buffer_for_enabled_channels():
         raise NotImplementedError("Method not yet available for this oscilloscope")

--- a/tests/trigger_conditions_test.py
+++ b/tests/trigger_conditions_test.py
@@ -1,0 +1,34 @@
+import sys
+import os
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, repo_root)
+if 'pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk']
+if 'pypicosdk.constants' in sys.modules:
+    del sys.modules['pypicosdk.constants']
+if 'pypicosdk.pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk.pypicosdk']
+import pypicosdk
+from pypicosdk import ps6000a, CHANNEL, ACTION
+from pypicosdk.constants import PICO_CONDITION, PICO_TRIGGER_STATE
+
+
+def test_set_trigger_channel_conditions_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+
+    condition = PICO_CONDITION(CHANNEL.A, PICO_TRIGGER_STATE.TRUE)
+    scope.set_trigger_channel_conditions([condition], ACTION.CLEAR_ALL | ACTION.ADD)
+    assert called['name'] == 'SetTriggerChannelConditions'
+
+
+
+


### PR DESCRIPTION
## Summary
- expose `PICO_TRIGGER_STATE` enum and `PICO_CONDITION` ctypes structure
- add `set_trigger_channel_conditions` wrapper
- test calling the new wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547404e1b883278db979f8b2aed342