### PR TITLE
Fix Pylance visibility for constants and triggers

### DIFF
--- a/pypicosdk/__init__.py
+++ b/pypicosdk/__init__.py
@@ -1,1 +1,11 @@
+"""Public package interface for :mod:`pypicosdk`."""
+
+# Import the implementation module under an internal name so we can
+# reference its ``__all__`` attribute for static type checkers like Pylance.
+from . import pypicosdk as _impl
+
+# Re-export everything defined in ``pypicosdk`` for backwards compatibility.
 from .pypicosdk import *
+
+# Expose the full list of public names for static analysers.
+__all__ = _impl.__all__

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -434,3 +434,36 @@ class PICO_CONDITION(ctypes.Structure):
         ("source_", ctypes.c_int32),
         ("condition_", ctypes.c_int32),
     ]
+
+
+# Public names exported by :mod:`pypicosdk.constants` for ``import *`` support.
+# This explicit list helps static analyzers like Pylance discover available
+# attributes when the parent package re-exports ``pypicosdk.constants`` using
+# ``from .constants import *``.
+__all__ = [
+    'UNIT_INFO',
+    'RESOLUTION',
+    'TRIGGER_DIR',
+    'WAVEFORM',
+    'CHANNEL',
+    'CHANNEL_NAMES',
+    'COUPLING',
+    'RANGE',
+    'RANGE_LIST',
+    'BANDWIDTH_CH',
+    'DATA_TYPE',
+    'ACTION',
+    'RATIO_MODE',
+    'POWER_SOURCE',
+    'SAMPLE_RATE',
+    'TIME_UNIT',
+    'PICO_TIME_UNIT',
+    'DIGITAL_PORT',
+    'DIGITAL_PORT_HYSTERESIS',
+    'AUXIO_MODE',
+    'PICO_TRIGGER_STATE',
+    'PICO_STREAMING_DATA_INFO',
+    'PICO_STREAMING_DATA_TRIGGER_INFO',
+    'PICO_TRIGGER_INFO',
+    'PICO_CONDITION',
+]

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -6,6 +6,7 @@ import time
 import typing
 
 from .error_list import ERROR_STRING
+from . import constants as _constants
 from .constants import *
 from .version import VERSION
 
@@ -1379,3 +1380,17 @@ class ps5000a(PicoScopeBase):
     
     def change_power_source(self, state):
         return super()._change_power_source(state)
+
+
+# Build an explicit list of public names for ``from pypicosdk import *``.
+# This improves support in static analyzers like Pylance.
+__all__ = list(_constants.__all__) + [
+    'PicoSDKNotFoundException',
+    'PicoSDKException',
+    'OverrangeWarning',
+    'PowerSupplyWarning',
+    'get_all_enumerated_units',
+    'PicoScopeBase',
+    'ps6000a',
+    'ps5000a',
+]


### PR DESCRIPTION
## Summary
- explicitly re-export package attributes
- define `__all__` in `constants` and implementation module for type checkers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685481c572088327bdcb590b65227482