### PR TITLE
Fix trigger time offset example

### DIFF
--- a/examples/example_6000a_trigger_time_offset_corrected.py
+++ b/examples/example_6000a_trigger_time_offset_corrected.py
@@ -24,8 +24,12 @@ uncorrected = []
 corrected_time_axes = []
 
 for _ in range(NCAPTURES):
-    # Capture a single waveform
-    buffers, time_axis = scope.run_simple_block_capture(timebase=TIMEBASE, samples=NSAMPLES)
+    # Capture a single waveform requesting trigger information
+    buffers, time_axis = scope.run_simple_block_capture(
+        timebase=TIMEBASE,
+        samples=NSAMPLES,
+        ratio_mode=psdk.RATIO_MODE.TRIGGER,
+    )
     waveform = buffers[channel]
     uncorrected.append(waveform)
 


### PR DESCRIPTION
## Summary
- request trigger data when capturing block in trigger offset example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548c071b80832797dfd123b9843894