### PR TITLE
Implement ps6000aSetDataBuffers

### DIFF
--- a/tests/data_buffers_test.py
+++ b/tests/data_buffers_test.py
@@ -1,0 +1,27 @@
+import sys
+import os
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, repo_root)
+if 'pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk']
+if 'pypicosdk.constants' in sys.modules:
+    del sys.modules['pypicosdk.constants']
+if 'pypicosdk.pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk.pypicosdk']
+
+from pypicosdk import ps6000a, CHANNEL
+
+
+def test_set_data_buffers_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.set_data_buffers(CHANNEL.A, 100)
+    assert called['name'] == 'SetDataBuffers'


### PR DESCRIPTION
## Summary
- implement `_set_data_buffers_ps6000a` and expose `set_data_buffers`
- add test for new ps6000aSetDataBuffers API
- document parameters for `set_data_buffers`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854ffb84a388327b20e345e4bc8a0fe