### PR TITLE
Add TRIGGER_CHANNEL_PROPERTIES support

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -419,6 +419,36 @@ class PICO_TRIGGER_INFO(ctypes.Structure):
     ]
 
 
+class PICO_TRIGGER_CHANNEL_PROPERTIES(ctypes.Structure):
+    """Trigger threshold configuration for a single channel.
+
+    The fields of this structure mirror the ``PICO_TRIGGER_CHANNEL_PROPERTIES``
+    definition in the PicoSDK headers.  Each attribute name ends with an
+    underscore so that the names match the underlying C struct when accessed
+    from Python.
+
+    Attributes:
+        thresholdUpper_: ADC counts for the upper trigger threshold.
+        thresholdUpperHysteresis_: Hysteresis applied to ``thresholdUpper_`` in
+            ADC counts.
+        thresholdLower_: ADC counts for the lower trigger threshold.
+        thresholdLowerHysteresis_: Hysteresis applied to ``thresholdLower_`` in
+            ADC counts.
+        channel_: Input channel that these properties apply to as a
+            :class:`CHANNEL` value.
+    """
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("thresholdUpper_", ctypes.c_int16),
+        ("thresholdUpperHysteresis_", ctypes.c_uint16),
+        ("thresholdLower_", ctypes.c_int16),
+        ("thresholdLowerHysteresis_", ctypes.c_uint16),
+        ("channel_", ctypes.c_int32),
+    ]
+
+
 class PICO_CONDITION(ctypes.Structure):
     """Trigger condition structure used by ``SetTriggerChannelConditions``.
 
@@ -465,5 +495,6 @@ __all__ = [
     'PICO_STREAMING_DATA_INFO',
     'PICO_STREAMING_DATA_TRIGGER_INFO',
     'PICO_TRIGGER_INFO',
+    'PICO_TRIGGER_CHANNEL_PROPERTIES',
     'PICO_CONDITION',
 ]

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -673,6 +673,41 @@ class PicoScopeBase:
             ctypes.c_int16(n_conditions),
             action,
         )
+
+    def set_trigger_channel_properties(
+        self,
+        properties: typing.Sequence[PICO_TRIGGER_CHANNEL_PROPERTIES],
+        aux_output_enable: int = 0,
+        auto_trigger_us: int = 0,
+    ) -> None:
+        """Configure trigger thresholds using ``SetTriggerChannelProperties``.
+
+        Args:
+            properties: Sequence of
+                :class:`~pypicosdk.constants.PICO_TRIGGER_CHANNEL_PROPERTIES`
+                structures describing the thresholds for each channel. An empty
+                sequence disables triggering.
+            aux_output_enable: Optional auxiliary output flag. Currently not
+                used by the driver.
+            auto_trigger_us: Time in microseconds to wait before automatically
+                triggering if no event occurs. ``0`` waits indefinitely.
+        """
+
+        n_props = len(properties)
+        if n_props:
+            props_array = (PICO_TRIGGER_CHANNEL_PROPERTIES * n_props)(*properties)
+            props_ptr = props_array
+        else:
+            props_ptr = None
+
+        self._call_attr_function(
+            "SetTriggerChannelProperties",
+            self.handle,
+            props_ptr,
+            ctypes.c_int16(n_props),
+            ctypes.c_int16(aux_output_enable),
+            ctypes.c_uint32(auto_trigger_us),
+        )
     
     def set_data_buffer_for_enabled_channels():
         raise NotImplementedError("Method not yet available for this oscilloscope")
@@ -1207,6 +1242,29 @@ class ps6000a(PicoScopeBase):
         """
 
         super().set_trigger_channel_conditions(conditions, action)
+
+    def set_trigger_channel_properties(
+        self,
+        properties: typing.Sequence[PICO_TRIGGER_CHANNEL_PROPERTIES],
+        aux_output_enable: int = 0,
+        auto_trigger_us: int = 0,
+    ) -> None:
+        """Configure channel thresholds using ``ps6000aSetTriggerChannelProperties``.
+
+        This method mirrors :meth:`PicoScopeBase.set_trigger_channel_properties`
+        while documenting the underlying 6000A API call.
+
+        Args:
+            properties: Sequence of :class:`~pypicosdk.constants.PICO_TRIGGER_CHANNEL_PROPERTIES`.
+            aux_output_enable: Optional auxiliary output flag.
+            auto_trigger_us: Auto-trigger timeout in microseconds.
+        """
+
+        super().set_trigger_channel_properties(
+            properties,
+            aux_output_enable,
+            auto_trigger_us,
+        )
     
     def set_data_buffer(self, channel:CHANNEL, samples:int, segment:int=0, datatype:DATA_TYPE=DATA_TYPE.INT16_T,
                         ratio_mode:RATIO_MODE=RATIO_MODE.RAW, action:ACTION=ACTION.CLEAR_ALL | ACTION.ADD) -> ctypes.Array:

--- a/tests/trigger_channel_properties_test.py
+++ b/tests/trigger_channel_properties_test.py
@@ -1,0 +1,28 @@
+import sys
+import os
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, repo_root)
+if 'pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk']
+if 'pypicosdk.constants' in sys.modules:
+    del sys.modules['pypicosdk.constants']
+if 'pypicosdk.pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk.pypicosdk']
+
+from pypicosdk import ps6000a, PICO_TRIGGER_CHANNEL_PROPERTIES
+
+
+def test_set_trigger_channel_properties_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    props = PICO_TRIGGER_CHANNEL_PROPERTIES(100, 10, -100, 10, 0)
+    scope.set_trigger_channel_properties([props])
+    assert called['name'] == 'SetTriggerChannelProperties'


### PR DESCRIPTION
## Summary
- expose `PICO_TRIGGER_CHANNEL_PROPERTIES` structure
- implement `set_trigger_channel_properties` in base and ps6000a wrapper classes
- test invocation of the new API call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554a8e056c832784678f6ad621251b