### PR TITLE
Update advanced trigger configuration example

### DIFF
--- a/examples/example_6000a_trigger_time_offset_corrected.py
+++ b/examples/example_6000a_trigger_time_offset_corrected.py
@@ -2,15 +2,37 @@ import pypicosdk as psdk
 import matplotlib.pyplot as plt
 import numpy as np
 
+
 # Scope setup
 scope = psdk.ps6000a()
 scope.open_unit(resolution=psdk.RESOLUTION._12BIT)
 
-# Configure channel and trigger
+# Configure channels
+scope.set_channel(channel=psdk.CHANNEL.A, coupling=psdk.COUPLING.DC, range=psdk.RANGE.V1)
+scope.set_channel(channel=psdk.CHANNEL.B, enabled=0, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
+scope.set_channel(channel=psdk.CHANNEL.C, enabled=0, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
+scope.set_channel(channel=psdk.CHANNEL.D, enabled=0, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
 channel = psdk.CHANNEL.A
-scope.set_channel(channel=channel, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
-scope.set_simple_trigger(channel=channel, threshold_mv=200,
-                         direction=psdk.TRIGGER_DIR.RISING, auto_trigger_ms=0)
+
+# Configure an advanced trigger on Channel A at 200 mV
+threshold_adc = scope.mv_to_adc(200, psdk.RANGE.V1)
+trigger_prop = psdk.PICO_TRIGGER_CHANNEL_PROPERTIES(
+    threshold_adc,
+    0,
+    threshold_adc,
+    0,
+    psdk.CHANNEL.A,
+)
+scope.set_trigger_channel_properties([trigger_prop])
+condition = psdk.PICO_CONDITION(psdk.CHANNEL.A, psdk.PICO_TRIGGER_STATE.TRUE)
+scope.set_trigger_channel_conditions([condition])
+
+direction = psdk.PICO_DIRECTION(
+    psdk.CHANNEL.A,
+    psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING,
+    psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
+)
+scope.set_trigger_channel_directions([direction])
 
 # Use the signal generator as a source
 scope.set_siggen(frequency=1000, pk2pk=0.9, wave_type=psdk.WAVEFORM.SINE)

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -466,6 +466,47 @@ class PICO_CONDITION(ctypes.Structure):
     ]
 
 
+class PICO_THRESHOLD_DIRECTION(IntEnum):
+    """Enumerates trigger threshold directions used with :class:`PICO_DIRECTION`."""
+
+    PICO_ABOVE = 0
+    PICO_BELOW = 1
+    PICO_RISING = 2
+    PICO_FALLING = 3
+    PICO_RISING_OR_FALLING = 4
+    PICO_ABOVE_LOWER = 5
+    PICO_BELOW_LOWER = 6
+    PICO_RISING_LOWER = 7
+    PICO_FALLING_LOWER = 8
+    PICO_INSIDE = PICO_ABOVE
+    PICO_OUTSIDE = PICO_BELOW
+    PICO_ENTER = PICO_RISING
+    PICO_EXIT = PICO_FALLING
+    PICO_ENTER_OR_EXIT = PICO_RISING_OR_FALLING
+    PICO_POSITIVE_RUNT = 9
+    PICO_NEGATIVE_RUNT = 10
+    PICO_NONE = PICO_RISING
+
+
+class PICO_THRESHOLD_MODE(IntEnum):
+    """Threshold operation mode values used in :class:`PICO_DIRECTION`."""
+
+    PICO_LEVEL = 0
+    PICO_WINDOW = 1
+
+
+class PICO_DIRECTION(ctypes.Structure):
+    """Structure used by ``SetTriggerChannelDirections`` to specify trigger directions."""
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("direction_", ctypes.c_int32),
+        ("thresholdMode_", ctypes.c_int32),
+    ]
+
+
 # Public names exported by :mod:`pypicosdk.constants` for ``import *`` support.
 # This explicit list helps static analyzers like Pylance discover available
 # attributes when the parent package re-exports ``pypicosdk.constants`` using
@@ -497,4 +538,7 @@ __all__ = [
     'PICO_TRIGGER_INFO',
     'PICO_TRIGGER_CHANNEL_PROPERTIES',
     'PICO_CONDITION',
+    'PICO_THRESHOLD_DIRECTION',
+    'PICO_THRESHOLD_MODE',
+    'PICO_DIRECTION',
 ]

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -708,6 +708,31 @@ class PicoScopeBase:
             ctypes.c_int16(aux_output_enable),
             ctypes.c_uint32(auto_trigger_us),
         )
+
+    def set_trigger_channel_directions(
+        self,
+        directions: typing.Sequence[PICO_DIRECTION],
+    ) -> None:
+        """Configure trigger directions using ``SetTriggerChannelDirections``.
+
+        Args:
+            directions: Sequence of :class:`~pypicosdk.constants.PICO_DIRECTION`
+                structures specifying the trigger direction for each channel.
+        """
+
+        n_dirs = len(directions)
+        if n_dirs:
+            dirs_array = (PICO_DIRECTION * n_dirs)(*directions)
+            dirs_ptr = dirs_array
+        else:
+            dirs_ptr = None
+
+        self._call_attr_function(
+            "SetTriggerChannelDirections",
+            self.handle,
+            dirs_ptr,
+            ctypes.c_int16(n_dirs),
+        )
     
     def set_data_buffer_for_enabled_channels():
         raise NotImplementedError("Method not yet available for this oscilloscope")
@@ -1265,6 +1290,14 @@ class ps6000a(PicoScopeBase):
             aux_output_enable,
             auto_trigger_us,
         )
+
+    def set_trigger_channel_directions(
+        self,
+        directions: typing.Sequence[PICO_DIRECTION],
+    ) -> None:
+        """Configure channel directions using ``ps6000aSetTriggerChannelDirections``."""
+
+        super().set_trigger_channel_directions(directions)
     
     def set_data_buffer(self, channel:CHANNEL, samples:int, segment:int=0, datatype:DATA_TYPE=DATA_TYPE.INT16_T,
                         ratio_mode:RATIO_MODE=RATIO_MODE.RAW, action:ACTION=ACTION.CLEAR_ALL | ACTION.ADD) -> ctypes.Array:

--- a/tests/trigger_directions_test.py
+++ b/tests/trigger_directions_test.py
@@ -1,0 +1,37 @@
+import sys
+import os
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, repo_root)
+if 'pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk']
+if 'pypicosdk.constants' in sys.modules:
+    del sys.modules['pypicosdk.constants']
+if 'pypicosdk.pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk.pypicosdk']
+
+from pypicosdk import (
+    ps6000a,
+    PICO_DIRECTION,
+    PICO_THRESHOLD_DIRECTION,
+    PICO_THRESHOLD_MODE,
+)
+
+
+def test_set_trigger_channel_directions_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    direction = PICO_DIRECTION(
+        0,
+        PICO_THRESHOLD_DIRECTION.PICO_RISING,
+        PICO_THRESHOLD_MODE.PICO_LEVEL,
+    )
+    scope.set_trigger_channel_directions([direction])
+    assert called['name'] == 'SetTriggerChannelDirections'


### PR DESCRIPTION
## Summary
- configure all channels in trigger time correction example using psdk types
- add PICO_DIRECTION related enums and wrapper helper
- use new API in advanced trigger example
- test SetTriggerChannelDirections call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68554caf3ed0832782222d15e5090528