### PR TITLE
Fix license path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description="Modern Python wrapper for PicoSDK",
     long_description=open("README.md").read() if os.path.exists("README.md") else "",
     long_description_content_type="text/markdown",
-    license_file="MIT",
+    license_file="LICENSE",
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
## Summary
- correct the `license_file` path in setup.py
- build wheel/sdist to ensure license is packaged

## Testing
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_6856c4b28d3c8327a2d8d9d0a0527e38