### PR TITLE
Fix trigger timeout units

### DIFF
--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -618,16 +618,16 @@ class PicoScopeBase:
         return self._error_handler(status)
     
     def set_simple_trigger(self, channel, threshold_mv, enable=True, direction=TRIGGER_DIR.RISING, delay=0, auto_trigger=0):
-        """
-        Sets up a simple trigger from a specified channel and threshold in mV
+        """Configure a simple edge trigger.
 
         Args:
             channel (int): The input channel to apply the trigger to.
             threshold_mv (float): Trigger threshold level in millivolts.
-            enable (bool, optional): Enables or disables the trigger. 
-            direction (TRIGGER_DIR, optional): Trigger direction (e.g., TRIGGER_DIR.RISING, TRIGGER_DIR.FALLING). 
-            delay (int, optional): Delay in samples after the trigger condition is met before starting capture. 
-            auto_trigger (int, optional): Timeout after which data capture proceeds even if no trigger occurs. 
+            enable (bool, optional): Enables or disables the trigger.
+            direction (TRIGGER_DIR, optional): Trigger direction (e.g., ``TRIGGER_DIR.RISING``).
+            delay (int, optional): Delay in samples after the trigger condition is met before starting capture.
+            auto_trigger (int, optional): Timeout in **microseconds** after which data capture proceeds even if no
+                trigger occurs.
         """
         if channel in self.range:
             threshold_adc = self.mv_to_adc(threshold_mv, self.range[channel])
@@ -1542,12 +1542,13 @@ class ps5000a(PicoScopeBase):
         Args:
             channel (int): The input channel to apply the trigger to.
             threshold_mv (float): Trigger threshold level in millivolts.
-            enable (bool, optional): Enables or disables the trigger. 
-            direction (TRIGGER_DIR, optional): Trigger direction (e.g., TRIGGER_DIR.RISING, TRIGGER_DIR.FALLING). 
-            delay (int, optional): Delay in samples after the trigger condition is met before starting capture. 
-            auto_trigger_ms (int, optional): Timeout in milliseconds after which data capture proceeds even if no trigger occurs. 
+            enable (bool, optional): Enables or disables the trigger.
+            direction (TRIGGER_DIR, optional): Trigger direction (e.g., TRIGGER_DIR.RISING, TRIGGER_DIR.FALLING).
+            delay (int, optional): Delay in samples after the trigger condition is met before starting capture.
+            auto_trigger_ms (int, optional): Timeout in milliseconds after which data capture proceeds even if no trigger occurs.
         """
-        return super().set_simple_trigger(channel, threshold_mv, enable, direction, delay, auto_trigger_ms)
+        auto_trigger_us = auto_trigger_ms * 1000
+        return super().set_simple_trigger(channel, threshold_mv, enable, direction, delay, auto_trigger_us)
     
     def set_data_buffer(self, channel, samples, segment=0, ratio_mode=0):
         return super()._set_data_buffer_ps5000a(channel, samples, segment, ratio_mode)

--- a/tests/simple_trigger_test.py
+++ b/tests/simple_trigger_test.py
@@ -1,0 +1,31 @@
+from pypicosdk import ps6000a, ps5000a, CHANNEL
+
+
+def test_ps6000a_simple_trigger_converts_ms_to_us():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.set_simple_trigger(CHANNEL.A, 100, auto_trigger_ms=5)
+    assert called['name'] == 'SetSimpleTrigger'
+    assert called['args'][-1] == 5000
+
+
+def test_ps5000a_simple_trigger_converts_ms_to_us():
+    scope = ps5000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.set_simple_trigger(CHANNEL.A, 100, auto_trigger_ms=7)
+    assert called['name'] == 'SetSimpleTrigger'
+    assert called['args'][-1] == 7000


### PR DESCRIPTION
## Summary
- document that `auto_trigger` is microseconds
- convert `auto_trigger_ms` to microseconds for ps5000a
- test simple trigger conversion logic for ps6000a and ps5000a

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c4aa4e688327bf271e66818a0670