### PR TITLE
Add ps6000aGetValuesTriggerTimeOffsetBulk support

### DIFF
--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -524,6 +524,45 @@ class PicoScopeBase:
             return info_array[0]
         return list(info_array)
 
+    def get_values_trigger_time_offset_bulk(
+        self,
+        from_segment_index: int,
+        to_segment_index: int,
+    ) -> list[tuple[int, PICO_TIME_UNIT]]:
+        """Retrieve trigger time offsets for a range of segments.
+
+        This method calls ``ps6000aGetValuesTriggerTimeOffsetBulk`` and
+        returns the trigger time offset and associated time unit for each
+        requested segment.
+
+        Args:
+            from_segment_index: Index of the first memory segment to query.
+            to_segment_index: Index of the last memory segment. If this value
+                is less than ``from_segment_index`` the driver wraps around.
+
+        Returns:
+            list[tuple[int, PICO_TIME_UNIT]]: ``[(offset, unit), ...]`` for each
+            segment beginning with ``from_segment_index``.
+        """
+
+        count = to_segment_index - from_segment_index + 1
+        times = (ctypes.c_int64 * count)()
+        units = (ctypes.c_int32 * count)()
+
+        self._call_attr_function(
+            "GetValuesTriggerTimeOffsetBulk",
+            self.handle,
+            ctypes.byref(times),
+            ctypes.byref(units),
+            ctypes.c_uint64(from_segment_index),
+            ctypes.c_uint64(to_segment_index),
+        )
+
+        results = []
+        for i in range(count):
+            results.append((times[i], PICO_TIME_UNIT(units[i])))
+        return results
+
 
     
     # Data conversion ADC/mV & ctypes/int 

--- a/tests/values_trigger_time_offset_bulk_test.py
+++ b/tests/values_trigger_time_offset_bulk_test.py
@@ -1,0 +1,15 @@
+from pypicosdk import ps6000a, PICO_TIME_UNIT
+
+
+def test_get_values_trigger_time_offset_bulk_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.get_values_trigger_time_offset_bulk(0, 3)
+    assert called['name'] == 'GetValuesTriggerTimeOffsetBulk'


### PR DESCRIPTION
## Summary
- implement `get_values_trigger_time_offset_bulk` for ps6000a
- test invocation of the new method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c724dae883279fe8d2f30a78d6a5