### PR TITLE
Add rapid block capture support

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -44,3 +44,22 @@ A longer example that continuously plots incoming data while streaming is availa
 maintains a rolling window controlled by `plot_samples`. If the plot window does not
 update, check the Matplotlib backend being used. Interactive backends such as
 `TkAgg` or `Qt5Agg` are required for live updates.
+
+## Rapid Block Example
+```python
+import pypicosdk as psdk
+
+scope = psdk.ps6000a()
+scope.open_unit()
+scope.set_channel(psdk.CHANNEL.A, psdk.RANGE.V1)
+scope.set_simple_trigger(psdk.CHANNEL.A, threshold_mv=0)
+captures, time_axis = scope.run_simple_rapid_block_capture(
+    timebase=2,
+    samples=1000,
+    n_captures=10,
+)
+scope.close_unit()
+```
+This helper configures memory segments, sets the capture count and retrieves
+all captures using ``GetValuesBulk``. See the API reference for details on
+``set_no_of_captures`` and ``get_values_bulk``.

--- a/examples/example_6000a_rapid_block.py
+++ b/examples/example_6000a_rapid_block.py
@@ -1,0 +1,33 @@
+import pypicosdk as psdk
+from matplotlib import pyplot as plt
+
+# Configuration
+TIMEBASE = 2
+SAMPLES = 1000
+CAPTURES = 4
+CHANNEL = psdk.CHANNEL.A
+RANGE = psdk.RANGE.V1
+
+# Initialise device
+scope = psdk.ps6000a()
+scope.open_unit()
+
+# Setup capture parameters
+scope.set_channel(channel=CHANNEL, range=RANGE)
+scope.set_simple_trigger(channel=CHANNEL, threshold_mv=0)
+
+# Run rapid block capture
+buffers, time_axis = scope.run_simple_rapid_block_capture(
+    timebase=TIMEBASE,
+    samples=SAMPLES,
+    n_captures=CAPTURES,
+)
+
+scope.close_unit()
+
+# Plot the first capture as an example
+plt.plot(time_axis, buffers[CHANNEL][0])
+plt.xlabel("Time (ns)")
+plt.ylabel("Amplitude (mV)")
+plt.grid(True)
+plt.show()

--- a/tests/rapid_block_test.py
+++ b/tests/rapid_block_test.py
@@ -1,0 +1,110 @@
+import ctypes
+from pypicosdk import ps6000a, CHANNEL, RANGE
+
+
+def test_set_no_of_captures_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.set_no_of_captures(4)
+    assert called['name'] == 'SetNoOfCaptures'
+
+
+def test_get_no_of_captures_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.get_no_of_captures()
+    assert called['name'] == 'GetNoOfCaptures'
+
+
+def test_get_values_bulk_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.is_ready = lambda: None
+    overflow = ctypes.c_int16()
+    scope.get_values_bulk(0, 10, 0, 1, 1, 0, overflow)
+    assert called['name'] == 'GetValuesBulk'
+
+
+def test_get_values_bulk_async_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.get_values_bulk_async(0, 10, 0, 1, 1, 0, None, None)
+    assert called['name'] == 'GetValuesBulkAsync'
+
+
+def test_get_values_overlapped_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.is_ready = lambda: None
+    overflow = ctypes.c_int16()
+    scope.get_values_overlapped(0, 10, 1, 0, 0, 1, overflow)
+    assert called['name'] == 'GetValuesOverlapped'
+
+
+def test_stop_using_get_values_overlapped_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.stop_using_get_values_overlapped()
+    assert called['name'] == 'StopUsingGetValuesOverlapped'
+
+
+def test_run_simple_rapid_block_capture_invocation():
+    scope = ps6000a('pytest')
+    calls = []
+
+    def fake_call(name, *args):
+        calls.append(name)
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.is_ready = lambda: None
+    scope.range = {CHANNEL.A: RANGE.V1}
+    scope.max_adc_value = 32767
+    scope.get_time_axis = lambda *args, **kwargs: []
+    scope.run_simple_rapid_block_capture(2, 10, 3)
+    assert 'MemorySegments' in calls
+    assert 'SetNoOfCaptures' in calls
+    assert 'RunBlock' in calls
+    assert 'GetValuesBulk' in calls


### PR DESCRIPTION
## Summary
- wrap ps6000a rapid block APIs
- add helper `run_simple_rapid_block_capture`
- provide example usage and docs
- cover new wrappers with tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d545719c83278c033b5bda7e2d2e