### PR TITLE
Add example for trigger time offset bulk

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -63,3 +63,24 @@ scope.close_unit()
 This helper configures memory segments, sets the capture count and retrieves
 all captures using ``GetValuesBulk``. See the API reference for details on
 ``set_no_of_captures`` and ``get_values_bulk``.
+
+## Trigger Time Offset Bulk Example
+Retrieve trigger offsets for multiple captures obtained in rapid block mode.
+
+```python
+import pypicosdk as psdk
+
+scope = psdk.ps6000a()
+scope.open_unit()
+scope.set_channel(psdk.CHANNEL.A, psdk.RANGE.V1)
+scope.set_simple_trigger(psdk.CHANNEL.A, threshold_mv=0)
+buffers, time_axis = scope.run_simple_rapid_block_capture(
+    timebase=2,
+    samples=1000,
+    n_captures=4,
+)
+offsets = scope.get_values_trigger_time_offset_bulk(0, 3)
+scope.close_unit()
+```
+``offsets`` contains a list of ``(offset, PICO_TIME_UNIT)`` tuples for each
+segment.

--- a/examples/example_6000a_trigger_time_offset_bulk.py
+++ b/examples/example_6000a_trigger_time_offset_bulk.py
@@ -1,0 +1,28 @@
+import pypicosdk as psdk
+
+# Capture configuration
+TIMEBASE = 2
+SAMPLES = 1000
+CAPTURES = 4
+CHANNEL = psdk.CHANNEL.A
+RANGE = psdk.RANGE.V1
+
+# Initialize and configure the scope
+scope = psdk.ps6000a()
+scope.open_unit()
+scope.set_channel(CHANNEL, RANGE)
+scope.set_simple_trigger(CHANNEL, threshold_mv=0)
+
+# Acquire multiple waveforms in rapid block mode
+buffers, time_axis = scope.run_simple_rapid_block_capture(
+    timebase=TIMEBASE,
+    samples=SAMPLES,
+    n_captures=CAPTURES,
+)
+
+# Retrieve the trigger time offset for each capture
+offsets = scope.get_values_trigger_time_offset_bulk(0, CAPTURES - 1)
+for i, (offset, unit) in enumerate(offsets):
+    print(f"Segment {i}: offset = {offset} {unit.name}")
+
+scope.close_unit()


### PR DESCRIPTION
## Summary
- include new example showing how to use `get_values_trigger_time_offset_bulk`
- document trigger time offset bulk retrieval in the ps6000a reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856db92b2388327972587e0f6d006a1