### PR TITLE
Fix trigger time bulk example

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -78,6 +78,7 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
     timebase=2,
     samples=1000,
     n_captures=4,
+    ratio_mode=psdk.RATIO_MODE.TRIGGER,
 )
 offsets = scope.get_values_trigger_time_offset_bulk(0, 3)
 scope.close_unit()

--- a/examples/example_6000a_trigger_time_offset_bulk.py
+++ b/examples/example_6000a_trigger_time_offset_bulk.py
@@ -18,6 +18,7 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
     timebase=TIMEBASE,
     samples=SAMPLES,
     n_captures=CAPTURES,
+    ratio_mode=psdk.RATIO_MODE.TRIGGER,
 )
 
 # Retrieve the trigger time offset for each capture


### PR DESCRIPTION
## Summary
- request trigger data when capturing for trigger-time-offset bulk example
- update ps6000a reference snippet accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856def260d88327bdc6f7ea7eb347cb