### PR TITLE
Fix trigger time bulk example

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -78,6 +78,8 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
     timebase=2,
     samples=1000,
     n_captures=4,
+    ratio=1,
+    ratio_mode=psdk.RATIO_MODE.TRIGGER,
 )
 offsets = scope.get_values_trigger_time_offset_bulk(0, 3)
 scope.close_unit()

--- a/examples/example_6000a_trigger_time_offset_bulk.py
+++ b/examples/example_6000a_trigger_time_offset_bulk.py
@@ -18,6 +18,8 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
     timebase=TIMEBASE,
     samples=SAMPLES,
     n_captures=CAPTURES,
+    ratio=1,
+    ratio_mode=psdk.RATIO_MODE.TRIGGER,
 )
 
 # Retrieve the trigger time offset for each capture


### PR DESCRIPTION
## Summary
- require non-zero ratio when requesting trigger info
- document ratio argument in example and reference snippet

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856def260d88327bdc6f7ea7eb347cb