### PR TITLE
Document trigger time offset resolution

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -86,3 +86,9 @@ scope.close_unit()
 ```
 ``offsets`` contains a list of ``(offset, PICO_TIME_UNIT)`` tuples for each
 segment.
+
+Although the driver reports very fine time offsets by interpolating between
+samples, the actual usable resolution is typically no better than about one
+tenth of the sampling interval.  See the
+``get_trigger_time_offset`` docstring for further discussion of this
+limitation.

--- a/examples/example_6000a_trigger_time_offset_bulk.py
+++ b/examples/example_6000a_trigger_time_offset_bulk.py
@@ -23,6 +23,8 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
 )
 
 # Retrieve the trigger time offset for each capture
+# Values below roughly one-tenth of the sample period may not be reliable
+# because the driver interpolates between samples.
 offsets = scope.get_values_trigger_time_offset_bulk(0, CAPTURES - 1)
 for i, (offset, unit) in enumerate(offsets):
     print(f"Segment {i}: offset = {offset} {unit.name}")

--- a/examples/example_6000a_trigger_time_offset_corrected.py
+++ b/examples/example_6000a_trigger_time_offset_corrected.py
@@ -57,6 +57,8 @@ for _ in range(NCAPTURES):
     uncorrected.append(waveform)
 
     # Retrieve trigger offset in nanoseconds and store corrected time axis
+    # Offsets smaller than roughly one-tenth of the sample period may not be
+    # reliable due to driver interpolation between samples.
     offset_ns = scope.get_trigger_time_offset(psdk.TIME_UNIT.NS)
     offsets.append(offset_ns)
     corrected_time_axes.append(np.array(time_axis) - offset_ns)

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -451,15 +451,23 @@ class PicoScopeBase:
         """
         Get the trigger time offset for jitter correction in waveforms.
 
+        The driver interpolates between adjacent samples to estimate when the
+        trigger actually occurred.  This means the value returned can have a
+        very fine granularity—down to femtoseconds—even though the effective
+        resolution is usually limited to roughly one-tenth of the sampling
+        interval in real-world use.
+
         Args:
             time_unit (TIME_UNIT): Desired unit for the returned offset.
-            segment_index (int, optional): The memory segment to query. Default is 0.
+            segment_index (int, optional): The memory segment to query. Default
+                is 0.
 
         Returns:
             int: Trigger time offset converted to ``time_unit``.
 
         Raises:
-            PicoSDKException: If the function call fails or preconditions are not met.
+            PicoSDKException: If the function call fails or preconditions are
+                not met.
         """
         time = ctypes.c_int64()
         returned_unit = ctypes.c_int32()


### PR DESCRIPTION
## Summary
- note that `get_trigger_time_offset` interpolates adjacent samples
- mention resolution caveat in the ps6000a reference
- clarify reliability of very small trigger offsets in examples

## Testing
- `mkdocs build -f docs/mkdocs.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fe7285308327a4b40deaad942a6d