### PR TITLE
Add eye diagram example

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -92,3 +92,9 @@ samples, the actual usable resolution is typically no better than about one
 tenth of the sampling interval.  See the
 ``get_trigger_time_offset`` docstring for further discussion of this
 limitation.
+
+## Eye Diagram Example
+An eye diagram overlays multiple waveform segments to visualize timing margins.
+See `examples/example_eye_diagram.py` for a complete script that captures
+repeated blocks, splits them into fixed length segments and uses Matplotlib to
+plot the overlay.

--- a/examples/example_eye_diagram.py
+++ b/examples/example_eye_diagram.py
@@ -1,0 +1,46 @@
+import pypicosdk as psdk
+from matplotlib import pyplot as plt
+
+# Configuration
+TIMEBASE = 2
+SAMPLES = 1000
+CAPTURES = 20
+CHANNEL = psdk.CHANNEL.A
+RANGE = psdk.RANGE.V1
+SAMPLES_PER_SYMBOL = 50
+
+# Initialise device
+scope = psdk.ps6000a()
+scope.open_unit()
+
+# Setup channel and trigger
+scope.set_channel(channel=CHANNEL, range=RANGE)
+scope.set_simple_trigger(channel=CHANNEL, threshold_mv=0)
+
+# Collect multiple captures
+captures = []
+for _ in range(CAPTURES):
+    buffers, time_axis = scope.run_simple_block_capture(
+        timebase=TIMEBASE,
+        samples=SAMPLES,
+    )
+    captures.append(buffers[CHANNEL])
+
+scope.close_unit()
+
+# Split each capture into segments for the eye diagram
+segments = []
+for buf in captures:
+    for idx in range(0, len(buf) - SAMPLES_PER_SYMBOL + 1, SAMPLES_PER_SYMBOL):
+        segments.append(buf[idx:idx + SAMPLES_PER_SYMBOL])
+
+# Plot overlay of segments
+segment_time = time_axis[:SAMPLES_PER_SYMBOL]
+for seg in segments:
+    plt.plot(segment_time, seg, color="C0", alpha=0.2)
+
+plt.xlabel("Time (ns)")
+plt.ylabel("Amplitude (mV)")
+plt.title("Eye Diagram")
+plt.grid(True)
+plt.show()


### PR DESCRIPTION
## Summary
- add example for overlaying repeated waveforms to plot an eye diagram
- reference new example from the ps6000a documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685708c6851883278d0af9f2204a4f3b