### PR TITLE
Improve eye diagram example

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -92,3 +92,10 @@ samples, the actual usable resolution is typically no better than about one
 tenth of the sampling interval.  See the
 ``get_trigger_time_offset`` docstring for further discussion of this
 limitation.
+
+## Eye Diagram Example
+An eye diagram overlays multiple waveform segments to visualize timing margins.
+See `examples/example_eye_diagram.py` for a script that captures repeated
+blocks, slices them into symbol-length segments and renders a heat-mapped
+overlay using Matplotlib. The example demonstrates using
+``sample_rate_to_timebase`` to set the desired sample rate.

--- a/examples/example_eye_diagram.py
+++ b/examples/example_eye_diagram.py
@@ -1,0 +1,66 @@
+import pypicosdk as psdk
+from matplotlib import pyplot as plt
+import numpy as np
+
+# Configuration
+SAMPLE_RATE_MSPS = 250  # Desired sample rate in MS/s
+SAMPLES = 1000
+CAPTURES = 20
+CHANNEL = psdk.CHANNEL.A
+RANGE = psdk.RANGE.V1
+SAMPLES_PER_SYMBOL = 50
+
+# Initialise device
+scope = psdk.ps6000a()
+scope.open_unit()
+TIMEBASE = scope.sample_rate_to_timebase(SAMPLE_RATE_MSPS, psdk.SAMPLE_RATE.MSPS)
+
+# Setup channel and trigger
+scope.set_channel(channel=CHANNEL, range=RANGE)
+scope.set_simple_trigger(channel=CHANNEL, threshold_mv=0)
+
+# Collect multiple captures
+captures = []
+for _ in range(CAPTURES):
+    buffers, time_axis = scope.run_simple_block_capture(
+        timebase=TIMEBASE,
+        samples=SAMPLES,
+    )
+    captures.append(buffers[CHANNEL])
+
+scope.close_unit()
+
+# Split each capture into segments for the eye diagram
+segments = []
+for buf in captures:
+    for idx in range(0, len(buf) - SAMPLES_PER_SYMBOL + 1, SAMPLES_PER_SYMBOL):
+        segments.append(buf[idx:idx + SAMPLES_PER_SYMBOL])
+
+# Build heatmap of waveform density
+segment_time = np.array(time_axis[:SAMPLES_PER_SYMBOL])
+segments_np = np.array(segments)
+
+# Flatten arrays for 2D histogram
+times = np.tile(segment_time, len(segments_np))
+values = segments_np.flatten()
+
+hist, x_edges, y_edges = np.histogram2d(
+    times,
+    values,
+    bins=[SAMPLES_PER_SYMBOL, 200],
+)
+
+extent = [x_edges[0], x_edges[-1], y_edges[0], y_edges[-1]]
+
+plt.imshow(
+    hist.T,
+    extent=extent,
+    origin="lower",
+    aspect="auto",
+    cmap="inferno",
+)
+plt.xlabel("Time (ns)")
+plt.ylabel("Amplitude (mV)")
+plt.title("Eye Diagram")
+plt.colorbar(label="Count")
+plt.show()


### PR DESCRIPTION
## Summary
- update eye diagram example to use `sample_rate_to_timebase`
- render waveforms with an inferno heatmap for a clearer eye diagram
- document the new usage in the ps6000a reference page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685708c6851883278d0af9f2204a4f3b