### PR TITLE
Promote inline argument style

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ The output should be similar to:
 
 Once tested, try an [example script from github](https://github.com/StuLawPico/pyPicoSDK_Playground) to get started.
 
+## Example style
+All examples pass arguments inline when calling API functions. This keeps each
+call self-contained and helps highlight the values in use:
+
+```python
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+```
+
+If you prefer, you can assign your own variables before calling the API:
+
+```python
+RANGE = psdk.RANGE.V1
+scope.set_channel(channel=psdk.CHANNEL.A, range=RANGE)
+```
+
+Timebase values are typically chosen using ``sample_rate_to_timebase``:
+
+```python
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+```
+
 ### Streaming Quickstart
 The following snippet performs a basic streaming capture using `run_simple_streaming_capture`:
 ```python

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,6 +29,30 @@ The output should be similar to:
 
 Once tested, try an [example script from github](https://github.com/StuLawPico/pyPicoSDK_Playground) to get started.
 
+### Example style
+Examples use inline arguments so that each API call shows the exact values used.
+For instance:
+
+```python
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+```
+
+You can store these values in variables if you prefer:
+
+```python
+RANGE = psdk.RANGE.V1
+scope.set_channel(channel=psdk.CHANNEL.A, range=RANGE)
+```
+
+Most examples select a timebase via ``sample_rate_to_timebase`` and include
+commented alternatives for direct timebase or interval conversion:
+
+```python
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+```
+
 ### Struct field names
 Many functions return data using ``ctypes`` structures. The attributes of
 these structures include a trailing underscore in their names. Use the

--- a/docs/docs/ref/introduction.md
+++ b/docs/docs/ref/introduction.md
@@ -3,6 +3,11 @@
 Each picoSDK class is built from a common class (PicoScopeBase) and a specific sub-class (ps####a).
 This allows each PicoScope to have shared, common functions i.e opening the unit, and specific functions i.e. changing power source on 5000 series PicoScopes.
 
+## Example style
+To make the API easy to follow, examples use inline arguments rather than
+setup variables. You can of course store values in variables first if that
+makes your code clearer.
+
 ## C PicoSDK (ctypes)
 This wrapper is built over the C DLL drivers from Pico Technology. 
 Therefore most basic python functions (such as `run_block()`) have a counterpart in the C library (e.g. `ps6000aRunBlockMode()`). 

--- a/examples/example_5000a_block_capture.py
+++ b/examples/example_5000a_block_capture.py
@@ -1,15 +1,11 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
+# Pico examples use inline argument values for clarity
+
 scope = psdk.ps5000a()
 
-range = psdk.RANGE._1V
-timebase = 2
-samples = 10000
-channel_a = psdk.CHANNEL.A
-channel_b = psdk.CHANNEL.B
-
-range = psdk.RANGE.V1
+SAMPLES = 10000
 
 scope.open_unit()
 
@@ -17,19 +13,26 @@ scope.open_unit(resolution=psdk.RESOLUTION._16BIT)
 scope.change_power_source(psdk.POWER_SOURCE.SUPPLY_NOT_CONNECTED)
 
 print(scope.get_unit_serial())
-scope.set_channel(channel_a, range, coupling=psdk.DC_COUPLING)
-scope.set_channel(channel_b, range, coupling=psdk.AC_COUPLING)
-scope.set_simple_trigger(channel_b, 
-                          threshold_mv=0, 
-                          auto_trigger_ms=5000)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1, coupling=psdk.DC_COUPLING)
+scope.set_channel(channel=psdk.CHANNEL.B, range=psdk.RANGE.V1, coupling=psdk.AC_COUPLING)
+scope.set_simple_trigger(
+    channel=psdk.CHANNEL.B,
+    threshold_mv=0,
+    auto_trigger_ms=5000,
+)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(125, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Easy Block Capture
-buffer = scope.run_simple_block_capture(timebase, samples)
+buffer = scope.run_simple_block_capture(TIMEBASE, SAMPLES)
 
 scope.close_unit()
 
 
 # print(buffer)
-plt.plot(buffer[channel_a])
-plt.plot(buffer[channel_b])
+plt.plot(buffer[psdk.CHANNEL.A])
+plt.plot(buffer[psdk.CHANNEL.B])
 plt.savefig('graph.png')

--- a/examples/example_6000a_advanced_block_capture.py
+++ b/examples/example_6000a_advanced_block_capture.py
@@ -7,25 +7,29 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
-# Setup variables
-timebase = 2
-samples = 100000
-channel = psdk.CHANNEL.A
-range = psdk.RANGE.V1
+# Pico examples use inline argument values for clarity
+
+# Capture configuration
+SAMPLES = 100000
 
 # Initialise PicoScope
 scope = psdk.ps6000a()
 scope.open_unit()
 print(scope.get_unit_serial())
 
-# Setup channels and trigger
-scope.set_channel(channel=channel, range=range)
-scope.set_simple_trigger(channel=channel, threshold_mv=0) 
+# Setup channels and trigger (inline arguments)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=0)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Run block capture and retrieve values
-channels_buffer = scope.set_data_buffer_for_enabled_channels(samples=samples)
-scope.run_block_capture(timebase=timebase, samples=samples)
-scope.get_values(samples)
+channels_buffer = scope.set_data_buffer_for_enabled_channels(samples=SAMPLES)
+scope.run_block_capture(timebase=TIMEBASE, samples=SAMPLES)
+scope.get_values(SAMPLES)
 
 # No ADC to mV conversion, add it here
 
@@ -34,10 +38,10 @@ scope.close_unit()
 
 # Build a Histogram of data
 plt.figure(0)
-plt.hist(channels_buffer[channel])
+plt.hist(channels_buffer[psdk.CHANNEL.A])
 plt.savefig('histogram_6000a.png')
 
 # Plot a graph of data
 plt.figure(1)
-plt.plot(channels_buffer[channel])
+plt.plot(channels_buffer[psdk.CHANNEL.A])
 plt.savefig('graph_6000a.png')

--- a/examples/example_6000a_aux_trigger_block.py
+++ b/examples/example_6000a_aux_trigger_block.py
@@ -1,11 +1,10 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
-# Setup variables
-TIMEBASE = 2
+# Pico examples use inline argument values for clarity
+
+# Capture configuration
 SAMPLES = 50_000
-CHANNEL = psdk.CHANNEL.A
-RANGE = psdk.RANGE.V1
 
 # Initialise PicoScope 6000
 scope = psdk.ps6000a()
@@ -14,13 +13,18 @@ scope.open_unit()
 # Configure AUX IO connector for triggering
 scope.set_aux_io_mode(psdk.AUXIO_MODE.INPUT)
 
-# Enable Channel A
-scope.set_channel(channel=CHANNEL, range=RANGE)
+# Enable Channel A (inline arguments)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
 
 # Trigger when AUX input is asserted
 condition = psdk.PICO_CONDITION(psdk.CHANNEL.TRIGGER_AUX, psdk.PICO_TRIGGER_STATE.TRUE)
 scope.set_trigger_channel_conditions([condition])
 scope.set_simple_trigger(channel=psdk.CHANNEL.TRIGGER_AUX, threshold_mv=0)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Run the block capture
 channel_buffer, time_axis = scope.run_simple_block_capture(TIMEBASE, SAMPLES)
@@ -29,7 +33,7 @@ channel_buffer, time_axis = scope.run_simple_block_capture(TIMEBASE, SAMPLES)
 scope.close_unit()
 
 # Plot data
-plt.plot(time_axis, channel_buffer[CHANNEL], label="Channel A")
+plt.plot(time_axis, channel_buffer[psdk.CHANNEL.A], label="Channel A")
 plt.xlabel("Time (ns)")
 plt.ylabel("Amplitude (mV)")
 plt.legend()

--- a/examples/example_6000a_continuous_streaming.py
+++ b/examples/example_6000a_continuous_streaming.py
@@ -19,6 +19,7 @@ from matplotlib import pyplot as plt
 from collections import deque
 from queue import Queue, Empty, Full
 import threading
+# Pico examples use inline argument values for clarity
 import time
 import psutil
 
@@ -33,7 +34,6 @@ sample_interval = 1
 sample_units = psdk.PICO_TIME_UNIT.US
 plot_samples = 5000  # samples shown on screen
 chunk_samples = 1000  # number of samples to read per iteration
-channel_a = psdk.CHANNEL.A
 voltage_range = psdk.RANGE.V1
 
 # SigGen variables
@@ -45,11 +45,11 @@ scope = psdk.ps6000a()
 scope.open_unit()
 
 # Output a sine wave to help visualise captured data
-scope.set_siggen(siggen_frequency, siggen_pk2pk, psdk.WAVEFORM.SINE)
+scope.set_siggen(frequency=1000, pk2pk=2, wave_type=psdk.WAVEFORM.SINE)
 
 # Setup channels and trigger
-scope.set_channel(channel=channel_a, range=voltage_range)
-scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=0)
 
 # Allocate a buffer for streaming
 # The same buffer is reused on every read so we don't need to re-register it
@@ -94,7 +94,7 @@ def streaming_worker() -> None:
 
             to_read = min(available, chunk_samples)
             data_array = (psdk.PICO_STREAMING_DATA_INFO * 1)()
-            data_array[0].channel_ = channel_a
+            data_array[0].channel_ = psdk.CHANNEL.A
             data_array[0].mode_ = psdk.RATIO_MODE.RAW
             data_array[0].type_ = psdk.DATA_TYPE.INT16_T
             data_array[0].noOfSamples_ = to_read
@@ -107,7 +107,7 @@ def streaming_worker() -> None:
             if num:
                 mv = [
                     scope.adc_to_mv(sample, voltage_range)
-                    for sample in channels_buffer[channel_a][:num]
+                    for sample in channels_buffer[psdk.CHANNEL.A][:num]
                 ]
                 try:
                     data_queue.put(mv, timeout=0.1)

--- a/examples/example_6000a_fft.py
+++ b/examples/example_6000a_fft.py
@@ -18,16 +18,15 @@
 
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
+
+# Pico examples use inline argument values for clarity
 import numpy as np
 from scipy.fft import rfft, rfftfreq
 from scipy.signal import windows
 
-# Setup variables
-timebase = 3
-samples = 5_000_000
-channel_a = psdk.CHANNEL.A
-range = psdk.RANGE.V1
-threshold = 0
+# Capture configuration
+SAMPLES = 5_000_000
+THRESHOLD = 0
 
 # SigGen variables
 frequency = 10_000_000
@@ -41,30 +40,35 @@ scope.open_unit()
 # Setup siggen
 scope.set_siggen(frequency, pk2pk, wave_type)
 
-# Setup channels and trigger
-scope.set_channel(channel=channel_a, range=range)
-scope.set_simple_trigger(channel=channel_a, threshold_mv=threshold)
+# Setup channels and trigger (inline arguments)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=THRESHOLD)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 3  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Run the block capture
-channel_buffer, time_axis = scope.run_simple_block_capture(timebase, samples)
+channel_buffer, time_axis = scope.run_simple_block_capture(TIMEBASE, SAMPLES)
 
 # Finish with PicoScope
 scope.close_unit()
 
 # Take out data (converting ns time axis to s)
-v = np.array(channel_buffer[channel_a])
+v = np.array(channel_buffer[psdk.CHANNEL.A])
 t = np.array(time_axis) * 1E-9
 
 # Get sample rate
 dt = t[1] - t[0]
 
 # Create a window and apply to data
-window = windows.hann(samples)
+window = windows.hann(SAMPLES)
 v_windowed = v * window
 
 # Create fft from data
 positive_amplitudes = np.abs(rfft(v_windowed))
-positive_freqs = rfftfreq(samples, dt)
+positive_freqs = rfftfreq(SAMPLES, dt)
 
 # # Convert mV to dB
 positive_dbs = np.abs(20 * np.log10(positive_amplitudes / 1e3))

--- a/examples/example_6000a_pk2pk_histogram.py
+++ b/examples/example_6000a_pk2pk_histogram.py
@@ -21,15 +21,15 @@ import pypicosdk as psdk
 import matplotlib.pyplot as plt
 import numpy as np
 
+# Pico examples use inline argument values for clarity
+
 # Scope setup
 scope = psdk.ps6000a()
 scope.open_unit(resolution=psdk.RESOLUTION._12BIT)
 
-# Set channels
-channel = psdk.CHANNEL.A
-
-scope.set_channel(channel=channel, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
-scope.set_simple_trigger(channel=channel, threshold_mv=200, direction=psdk.TRIGGER_DIR.RISING, auto_trigger_ms=0)
+# Set channels (inline arguments)
+scope.set_channel(channel=psdk.CHANNEL.A, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=200, direction=psdk.TRIGGER_DIR.RISING, auto_trigger_ms=0)
 
 # Setup SigGen
 scope.set_siggen(frequency=1000, pk2pk=0.9, wave_type=psdk.WAVEFORM.SINE)
@@ -50,7 +50,7 @@ for _ in range(nCaptures):
     )
 
     # Add channel data to list
-    waveform = channel_buffer[channel]
+    waveform = channel_buffer[psdk.CHANNEL.A]
     waveforms.append(waveform)
 
     # Calculate pk2pk values, add to list

--- a/examples/example_6000a_rapid_block.py
+++ b/examples/example_6000a_rapid_block.py
@@ -1,20 +1,24 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
+# Pico examples use inline argument values for clarity
+
 # Configuration
-TIMEBASE = 2
 SAMPLES = 1000
 CAPTURES = 4
-CHANNEL = psdk.CHANNEL.A
-RANGE = psdk.RANGE.V1
 
 # Initialise device
 scope = psdk.ps6000a()
 scope.open_unit()
 
-# Setup capture parameters
-scope.set_channel(channel=CHANNEL, range=RANGE)
-scope.set_simple_trigger(channel=CHANNEL, threshold_mv=0)
+# Setup capture parameters (inline arguments)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=0)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Run rapid block capture
 buffers, time_axis = scope.run_simple_rapid_block_capture(
@@ -26,7 +30,7 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
 scope.close_unit()
 
 # Plot the first capture as an example
-plt.plot(time_axis, buffers[CHANNEL][0])
+plt.plot(time_axis, buffers[psdk.CHANNEL.A][0])
 plt.xlabel("Time (ns)")
 plt.ylabel("Amplitude (mV)")
 plt.grid(True)

--- a/examples/example_6000a_siggen.py
+++ b/examples/example_6000a_siggen.py
@@ -1,14 +1,13 @@
 import pypicosdk as psdk
 
-scope = psdk.ps6000a()
+# Pico examples use inline argument values for clarity
 
-frequency_hz = 1000
-voltage_pk2pk = 2
-wave_type = psdk.WAVEFORM.SINE
+scope = psdk.ps6000a()
 
 scope.open_unit()
 
-scope.set_siggen(frequency_hz, voltage_pk2pk, wave_type)
+# Setup signal generator (inline arguments)
+scope.set_siggen(frequency=1000, pk2pk=2, wave_type=psdk.WAVEFORM.SINE)
 input("Return to continue... ")
 
 scope.close_unit()

--- a/examples/example_6000a_siggen_block_capture.py
+++ b/examples/example_6000a_siggen_block_capture.py
@@ -1,11 +1,10 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
-# Setup variables
-timebase = 2
-samples = 50_000
-channel_a = psdk.CHANNEL.A
-range = psdk.RANGE.V1
+# Pico examples use inline argument values for clarity
+
+# Capture configuration
+SAMPLES = 50_000
 
 # SigGen variables
 frequency = 100_000
@@ -19,18 +18,23 @@ scope.open_unit()
 # Setup siggen
 scope.set_siggen(frequency, pk2pk, wave_type)
 
-# Setup channels and trigger
-scope.set_channel(channel=channel_a, range=range)
-scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
+# Setup channels and trigger (inline arguments)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=0)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Run the block capture
-channel_buffer, time_axis = scope.run_simple_block_capture(timebase, samples)
+channel_buffer, time_axis = scope.run_simple_block_capture(TIMEBASE, SAMPLES)
 
 # Finish with PicoScope
 scope.close_unit()
 
 # Plot data to pyplot
-plt.plot(time_axis, channel_buffer[channel_a])
+plt.plot(time_axis, channel_buffer[psdk.CHANNEL.A])
 
 # Add labels to pyplot
 plt.xlabel("Time (ns)")     

--- a/examples/example_6000a_simple_block_capture.py
+++ b/examples/example_6000a_simple_block_capture.py
@@ -1,31 +1,34 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
-# Setup variables
-timebase = 2
-samples = 50_000
-channel_a = psdk.CHANNEL.A
-channel_b = psdk.CHANNEL.B
-range = psdk.RANGE.V1
+# Pico examples use inline argument values for clarity
+
+# Capture configuration
+SAMPLES = 50_000
 
 # Initialise PicoScope 6000
 scope = psdk.ps6000a()
 scope.open_unit()
 
-# Setup channels and trigger
-scope.set_channel(channel=channel_a, range=range)
-scope.set_channel(channel=channel_b, range=range)
-scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
+# Setup channels and trigger (inline arguments)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_channel(channel=psdk.CHANNEL.B, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=0)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Run the block capture
-channel_buffer, time_axis = scope.run_simple_block_capture(timebase, samples)
+channel_buffer, time_axis = scope.run_simple_block_capture(TIMEBASE, SAMPLES)
 
 # Finish with PicoScope
 scope.close_unit()
 
 # Plot data to pyplot
-plt.plot(time_axis, channel_buffer[channel_a], label='Channel A')
-plt.plot(time_axis, channel_buffer[channel_b], label='Channel B')
+plt.plot(time_axis, channel_buffer[psdk.CHANNEL.A], label="Channel A")
+plt.plot(time_axis, channel_buffer[psdk.CHANNEL.B], label="Channel B")
 
 # Add labels to pyplot
 plt.xlabel("Time (ns)")     

--- a/examples/example_6000a_simple_streaming.py
+++ b/examples/example_6000a_simple_streaming.py
@@ -1,12 +1,12 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
-# Setup variables
+# Pico examples use inline argument values for clarity
+
+# Streaming configuration
 sample_interval = 1
 sample_units = psdk.PICO_TIME_UNIT.US
 samples = 5000
-channel_a = psdk.CHANNEL.A
-range = psdk.RANGE.V1
 
 # SigGen variables
 siggen_frequency = 1000  # Hz
@@ -17,11 +17,11 @@ scope = psdk.ps6000a()
 scope.open_unit()
 
 # Output a sine wave to help visualise captured data
-scope.set_siggen(siggen_frequency, siggen_pk2pk, psdk.WAVEFORM.SINE)
+scope.set_siggen(frequency=1000, pk2pk=2, wave_type=psdk.WAVEFORM.SINE)
 
 # Setup channels and trigger
-scope.set_channel(channel=channel_a, range=range)
-scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=0)
 
 # Run streaming capture
 channels, time_axis = scope.run_simple_streaming_capture(
@@ -37,7 +37,7 @@ channels, time_axis = scope.run_simple_streaming_capture(
 scope.close_unit()
 
 # Plot data to pyplot
-plt.plot(time_axis, channels[channel_a])
+plt.plot(time_axis, channels[psdk.CHANNEL.A])
 plt.xlabel("Time (s)")
 plt.ylabel("Amplitude (mV)")
 plt.grid(True)

--- a/examples/example_6000a_timebase.py
+++ b/examples/example_6000a_timebase.py
@@ -3,6 +3,8 @@ Example to figure out the correct timebase value for a specific interval.
 """
 from pypicosdk import ps6000a, CHANNEL, RANGE, SAMPLE_RATE, TIME_UNIT
 
+# Pico examples use inline argument values for clarity
+
 # Variables
 interval_s = 10E-9 # 10 us
 

--- a/examples/example_6000a_trigger_time_offset_bulk.py
+++ b/examples/example_6000a_trigger_time_offset_bulk.py
@@ -1,17 +1,21 @@
 import pypicosdk as psdk
 
+# Pico examples use inline argument values for clarity
+
 # Capture configuration
-TIMEBASE = 2
 SAMPLES = 1000
 CAPTURES = 4
-CHANNEL = psdk.CHANNEL.A
-RANGE = psdk.RANGE.V1
 
 # Initialize and configure the scope
 scope = psdk.ps6000a()
 scope.open_unit()
-scope.set_channel(CHANNEL, RANGE)
-scope.set_simple_trigger(CHANNEL, threshold_mv=0)
+scope.set_channel(psdk.CHANNEL.A, psdk.RANGE.V1)
+scope.set_simple_trigger(psdk.CHANNEL.A, threshold_mv=0)
+
+# Preferred: convert sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
 
 # Acquire multiple waveforms in rapid block mode
 buffers, time_axis = scope.run_simple_rapid_block_capture(

--- a/examples/example_6000a_trigger_time_offset_corrected.py
+++ b/examples/example_6000a_trigger_time_offset_corrected.py
@@ -2,6 +2,8 @@ import pypicosdk as psdk
 import matplotlib.pyplot as plt
 import numpy as np
 
+# Pico examples use inline argument values for clarity
+
 
 # Scope setup
 scope = psdk.ps6000a()
@@ -12,7 +14,6 @@ scope.set_channel(channel=psdk.CHANNEL.A, coupling=psdk.COUPLING.DC, range=psdk.
 scope.set_channel(channel=psdk.CHANNEL.B, enabled=0, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
 scope.set_channel(channel=psdk.CHANNEL.C, enabled=0, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
 scope.set_channel(channel=psdk.CHANNEL.D, enabled=0, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
-channel = psdk.CHANNEL.A
 
 # Configure an advanced trigger on Channel A at 200 mV
 threshold_adc = scope.mv_to_adc(200, psdk.RANGE.V1)
@@ -53,7 +54,7 @@ for _ in range(NCAPTURES):
         samples=NSAMPLES,
         ratio_mode=psdk.RATIO_MODE.TRIGGER,
     )
-    waveform = buffers[channel]
+    waveform = buffers[psdk.CHANNEL.A]
     uncorrected.append(waveform)
 
     # Retrieve trigger offset in nanoseconds and store corrected time axis

--- a/examples/example_enumerate_units.py
+++ b/examples/example_enumerate_units.py
@@ -4,6 +4,8 @@
 
 import pypicosdk as psdk
 
+# Pico examples use inline argument values for clarity
+
 # Enumerate units
 n_units, unit_list = psdk.get_all_enumerated_units()
 

--- a/examples/example_eye_diagram.py
+++ b/examples/example_eye_diagram.py
@@ -2,6 +2,8 @@ import pypicosdk as psdk
 from matplotlib import pyplot as plt
 import numpy as np
 
+# Pico examples use inline argument values for clarity
+
 # Configuration
 # Capture a CAN H signal using a 10:1 probe. The bus typically swings between
 # roughly 1.5–3.5 V, so with the probe attenuation the scope sees about
@@ -11,8 +13,6 @@ SAMPLE_RATE_MSPS = 40  # ADC sample rate in mega-samples per second
 BIT_RATE_MBPS = 0.4   # CAN bit rate (400 kbps)
 SAMPLES = 1000        # Samples captured in each block
 CAPTURES = 20         # Blocks overlaid in the eye diagram
-CHANNEL = psdk.CHANNEL.A
-RANGE = psdk.RANGE.V1
 
 # Derived value: number of ADC samples representing one bit/symbol.  With the
 # default values above this is 100 samples per CAN bit.
@@ -25,9 +25,9 @@ scope.open_unit()
 # Configure channels before calculating the timebase. The SDK requires at least
 # one channel to be enabled for ``sample_rate_to_timebase`` to succeed.
 scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1, probe_scale=10, offset=-0.3)
-scope.set_channel(channel=psdk.CHANNEL.B, enabled=0, range=RANGE)
-scope.set_channel(channel=psdk.CHANNEL.C, enabled=0, range=RANGE)
-scope.set_channel(channel=psdk.CHANNEL.D, enabled=0, range=RANGE)
+scope.set_channel(channel=psdk.CHANNEL.B, enabled=0, range=psdk.RANGE.V1)
+scope.set_channel(channel=psdk.CHANNEL.C, enabled=0, range=psdk.RANGE.V1)
+scope.set_channel(channel=psdk.CHANNEL.D, enabled=0, range=psdk.RANGE.V1)
 
 # Convert the desired sample rate into a driver-specific timebase value.
 TIMEBASE = scope.sample_rate_to_timebase(SAMPLE_RATE_MSPS, psdk.SAMPLE_RATE.MSPS)
@@ -35,7 +35,7 @@ TIMEBASE = scope.sample_rate_to_timebase(SAMPLE_RATE_MSPS, psdk.SAMPLE_RATE.MSPS
 # Setup trigger.
 # 250 mV at the scope corresponds to a mid-level threshold on a CAN H signal when using a 10:1 probe.
 scope.set_simple_trigger(
-    channel=CHANNEL,
+    channel=psdk.CHANNEL.A,
     threshold_mv=250,
     direction=psdk.TRIGGER_DIR.RISING_OR_FALLING,
     auto_trigger_ms=0,
@@ -48,7 +48,7 @@ for _ in range(CAPTURES):
         timebase=TIMEBASE,
         samples=SAMPLES,
     )
-    captures.append(buffers[CHANNEL])
+    captures.append(buffers[psdk.CHANNEL.A])
 
 scope.close_unit()
 


### PR DESCRIPTION
## Summary
- document using inline arguments in examples
- show how to assign your own variables
- prefer `sample_rate_to_timebase` in examples and comment alternatives
- update all examples to use inline parameters and add clarifying comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685874dd44ac832784230fbb47e6660f