### PR TITLE
Update eye diagram example

### DIFF
--- a/examples/example_eye_diagram.py
+++ b/examples/example_eye_diagram.py
@@ -11,12 +11,14 @@ import numpy as np
 # level centred on the display.
 SAMPLE_RATE_MSPS = 40  # ADC sample rate in mega-samples per second
 BIT_RATE_MBPS = 0.4   # CAN bit rate (400 kbps)
-SAMPLES = 1000        # Samples captured in each block
-CAPTURES = 20         # Blocks overlaid in the eye diagram
 
-# Derived value: number of ADC samples representing one bit/symbol.  With the
+# Derived value: number of ADC samples representing one bit/symbol. With the
 # default values above this is 100 samples per CAN bit.
 SAMPLES_PER_SYMBOL = int(SAMPLE_RATE_MSPS / BIT_RATE_MBPS)
+
+# Capture one symbol per block
+SAMPLES = SAMPLES_PER_SYMBOL
+CAPTURES = 20  # Blocks overlaid in the eye diagram
 
 # Initialise device
 scope = psdk.ps6000a()
@@ -32,36 +34,43 @@ scope.set_channel(channel=psdk.CHANNEL.D, enabled=0, range=psdk.RANGE.V1)
 # Convert the desired sample rate into a driver-specific timebase value.
 TIMEBASE = scope.sample_rate_to_timebase(SAMPLE_RATE_MSPS, psdk.SAMPLE_RATE.MSPS)
 
-# Setup trigger.
+# Setup an advanced trigger.
 # 250 mV at the scope corresponds to a mid-level threshold on a CAN H signal when using a 10:1 probe.
-scope.set_simple_trigger(
-    channel=psdk.CHANNEL.A,
-    threshold_mv=250,
-    direction=psdk.TRIGGER_DIR.RISING_OR_FALLING,
-    auto_trigger_ms=0,
+threshold_adc = scope.mv_to_adc(250, psdk.RANGE.V1)
+prop = psdk.PICO_TRIGGER_CHANNEL_PROPERTIES(
+    threshold_adc,
+    0,
+    threshold_adc,
+    0,
+    psdk.CHANNEL.A,
 )
+scope.set_trigger_channel_properties([prop])
+scope.set_trigger_channel_conditions([
+    psdk.PICO_CONDITION(psdk.CHANNEL.A, psdk.PICO_TRIGGER_STATE.TRUE)
+])
+scope.set_trigger_channel_directions([
+    psdk.PICO_DIRECTION(
+        psdk.CHANNEL.A,
+        psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING_OR_FALLING,
+        psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
+    )
+])
 
 # Collect multiple captures
-captures = []
-for _ in range(CAPTURES):
-    buffers, time_axis = scope.run_simple_block_capture(
-        timebase=TIMEBASE,
-        samples=SAMPLES,
-    )
-    captures.append(buffers[psdk.CHANNEL.A])
+buffers, time_axis = scope.run_simple_rapid_block_capture(
+    timebase=TIMEBASE,
+    samples=SAMPLES,
+    n_captures=CAPTURES,
+)
+captures = buffers[psdk.CHANNEL.A]
 
 scope.close_unit()
 
-# Split each capture into symbol-sized segments for the eye diagram. Each
-# segment spans one bit and contains ``SAMPLES_PER_SYMBOL`` ADC samples.
-segments = []
-for buf in captures:
-    for idx in range(0, len(buf) - SAMPLES_PER_SYMBOL + 1, SAMPLES_PER_SYMBOL):
-        segments.append(buf[idx:idx + SAMPLES_PER_SYMBOL])
+# //todo: explore splitting captures into multiple segments again later
+segments_np = np.array(captures)
 
-# Time axis corresponding to the samples in a single symbol.
-segment_time = np.array(time_axis[:SAMPLES_PER_SYMBOL])
-segments_np = np.array(segments)
+# Time axis corresponding to the captured samples
+segment_time = np.array(time_axis)
 
 # Flatten arrays for 2D histogram
 times = np.tile(segment_time, len(segments_np))


### PR DESCRIPTION
## Summary
- use rapid block mode and advanced trigger
- capture one symbol per block
- simplify eye diagram overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685880b780e08327ad55c3b5a2e19e40