### PR TITLE
Update eye diagram example for log plot and trigger position

### DIFF
--- a/examples/example_eye_diagram.py
+++ b/examples/example_eye_diagram.py
@@ -1,5 +1,6 @@
 import pypicosdk as psdk
 from matplotlib import pyplot as plt
+from matplotlib.colors import LogNorm
 import numpy as np
 
 # Pico examples use inline argument values for clarity
@@ -61,6 +62,7 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
     timebase=TIMEBASE,
     samples=SAMPLES,
     n_captures=CAPTURES,
+    pre_trig_percent=20,
 )
 captures = buffers[psdk.CHANNEL.A]
 
@@ -90,6 +92,7 @@ plt.imshow(
     origin="lower",
     aspect="auto",
     cmap="inferno",
+    norm=LogNorm(vmin=1),
 )
 plt.xlabel("Time (ns)")
 plt.ylabel("Amplitude (mV)")


### PR DESCRIPTION
## Summary
- allow adjusting pre-trigger percentage
- display hits using logarithmic scale

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858854d2054832795ec2bbd93c4a968