### PR TITLE
Improve eye diagram example

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -96,8 +96,9 @@ limitation.
 ## Eye Diagram Example
 An eye diagram overlays multiple waveform segments to visualize timing margins.
 See `examples/example_eye_diagram.py` for a script that captures repeated
-blocks, slices them into symbol-length segments and renders a heat-mapped
-overlay using Matplotlib.  It is pre-configured for a 400 kbps I²C bus using a
-10:1 probe, so the scope input range is set to ±500 mV to accommodate a 0–5 V
-signal.  The script also demonstrates using ``sample_rate_to_timebase`` to set
-the desired sample rate and triggers on either a rising or falling edge.
+blocks, each spanning two symbols so the triggered bit is centred with half a
+bit of context either side. The script renders a heat-mapped overlay using
+Matplotlib.  It is pre-configured for a 400 kbps I²C bus using a 10:1 probe, so
+the scope input range is set to ±500 mV to accommodate a 0–5 V signal.  The
+example also demonstrates using ``sample_rate_to_timebase`` to set the desired
+sample rate and triggers on either a rising or falling edge.


### PR DESCRIPTION
## Summary
- center a CAN bit within the capture window
- pre-trigger percent calculated from samples-per-symbol
- display histogram using `np.log1p` scaling
- document new behaviour in `ps6000a` reference

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685888a26d148327b1a0c62d0255b0f5