### PR TITLE
Add dead time calculation example

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -102,3 +102,8 @@ Matplotlib.  It is pre-configured for a 400 kbps I²C bus using a 10:1 probe, s
 the scope input range is set to ±500 mV to accommodate a 0–5 V signal.  The
 example also demonstrates using ``sample_rate_to_timebase`` to set the desired
 sample rate and triggers on either a rising or falling edge.
+
+## Dead Time Example
+The `timeStampCounter` field of :class:`PICO_TRIGGER_INFO` lets you measure the delay between consecutive captures.
+See `examples/example_6000a_dead_time.py` for a script that performs a rapid block run,
+retrieves trigger information for each segment and plots the dead time between triggers.

--- a/examples/example_6000a_dead_time.py
+++ b/examples/example_6000a_dead_time.py
@@ -1,0 +1,52 @@
+import pypicosdk as psdk
+from matplotlib import pyplot as plt
+
+# Pico examples use inline argument values for clarity
+
+# Capture configuration
+SAMPLES = 1000
+CAPTURES = 8
+
+# Initialize scope
+scope = psdk.ps6000a()
+scope.open_unit()
+
+# Configure channel and trigger
+scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
+scope.set_simple_trigger(channel=psdk.CHANNEL.A, threshold_mv=0)
+
+# Convert desired sample rate to timebase
+TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)
+
+# Perform rapid block capture
+buffers, time_axis = scope.run_simple_rapid_block_capture(
+    timebase=TIMEBASE,
+    samples=SAMPLES,
+    n_captures=CAPTURES,
+)
+
+# Retrieve trigger timing information for each segment
+trigger_info = scope.get_trigger_info(0, CAPTURES)
+
+scope.close_unit()
+
+# Calculate dead time between captures
+SAMPLE_INTERVAL_NS = time_axis[1] - time_axis[0]
+COUNTER_MASK = 0x00FFFFFFFFFFFFFF
+
+dead_times = []
+for prev, curr in zip(trigger_info[:-1], trigger_info[1:]):
+    diff_samples = (curr.timeStampCounter_ - prev.timeStampCounter_) & COUNTER_MASK
+    dead_samples = diff_samples - SAMPLES
+    dead_times.append(dead_samples * SAMPLE_INTERVAL_NS)
+
+print("Dead time between captures (ns):")
+for i, dt in enumerate(dead_times, start=1):
+    print(f"{i}->{i+1}: {dt:.2f}")
+
+plt.plot(range(1, CAPTURES), dead_times, marker="o")
+plt.xlabel("Capture index")
+plt.ylabel("Dead time (ns)")
+plt.title("Dead time between captures")
+plt.grid(True)
+plt.show()


### PR DESCRIPTION
## Summary
- add example_6000a_dead_time.py demonstrating use of `timeStampCounter`
- document the new example in `ps6000a` reference docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859c26ff43c8327b41189fab25f3ed9