### PR TITLE
Use advanced trigger helper in examples

### DIFF
--- a/examples/example_6000a_trigger_time_offset_corrected.py
+++ b/examples/example_6000a_trigger_time_offset_corrected.py
@@ -16,18 +16,13 @@ scope.set_channel(channel=psdk.CHANNEL.C, enabled=0, coupling=psdk.COUPLING.DC, 
 scope.set_channel(channel=psdk.CHANNEL.D, enabled=0, coupling=psdk.COUPLING.DC, range=psdk.RANGE.mV500)
 
 # Configure an advanced trigger on Channel A at 200 mV
-threshold_adc = scope.mv_to_adc(200, psdk.RANGE.V1)
-scope.set_trigger_channel_properties(
-    threshold_adc, 0, threshold_adc, 0, psdk.CHANNEL.A
-)
-scope.set_trigger_channel_conditions(
-    psdk.CHANNEL.A, psdk.PICO_TRIGGER_STATE.TRUE
-)
-
-scope.set_trigger_channel_directions(
-    psdk.CHANNEL.A,
-    psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING,
-    psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
+scope.set_advanced_trigger(
+    channel=psdk.CHANNEL.A,
+    state=psdk.PICO_TRIGGER_STATE.TRUE,
+    direction=psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING,
+    threshold_mode=psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
+    threshold_upper_mv=200,
+    threshold_lower_mv=200,
 )
 
 # Use the signal generator as a source

--- a/examples/example_eye_diagram.py
+++ b/examples/example_eye_diagram.py
@@ -37,18 +37,15 @@ TIMEBASE = scope.sample_rate_to_timebase(SAMPLE_RATE_MSPS, psdk.SAMPLE_RATE.MSPS
 
 # Setup an advanced trigger.
 # 250 mV at the scope corresponds to a mid-level threshold on a CAN H signal when using a 10:1 probe.
-threshold_adc = scope.mv_to_adc(250, psdk.RANGE.V1)
-scope.set_trigger_channel_properties(
-    threshold_adc, 0, threshold_adc, 0, psdk.CHANNEL.A
+scope.set_advanced_trigger(
+    channel=psdk.CHANNEL.A,
+    state=psdk.PICO_TRIGGER_STATE.TRUE,
+    direction=psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING_OR_FALLING,
+    threshold_mode=psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
+    threshold_upper_mv=250,
+    threshold_lower_mv=250,
 )
-scope.set_trigger_channel_conditions(
-    psdk.CHANNEL.A, psdk.PICO_TRIGGER_STATE.TRUE
-)
-scope.set_trigger_channel_directions(
-    psdk.CHANNEL.A,
-    psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING_OR_FALLING,
-    psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
-)
+
 
 # Collect multiple captures
 # Pre-trigger percentage aligns half a bit before the threshold crossing so the


### PR DESCRIPTION
## Summary
- use `set_advanced_trigger` in `example_6000a_trigger_time_offset_corrected.py`
- use `set_advanced_trigger` in `example_eye_diagram.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac7bea76c83278dcf294081e08dbc