### PR TITLE
Improve trigger docs and aux example

### DIFF
--- a/examples/example_6000a_aux_trigger_block.py
+++ b/examples/example_6000a_aux_trigger_block.py
@@ -16,11 +16,16 @@ scope.set_aux_io_mode(psdk.AUXIO_MODE.INPUT)
 # Enable Channel A (inline arguments)
 scope.set_channel(channel=psdk.CHANNEL.A, range=psdk.RANGE.V1)
 
-# Trigger when AUX input is asserted
+# Trigger when AUX input is asserted using advanced trigger APIs
 scope.set_trigger_channel_conditions(
     psdk.CHANNEL.TRIGGER_AUX, psdk.PICO_TRIGGER_STATE.TRUE
 )
-scope.set_simple_trigger(channel=psdk.CHANNEL.TRIGGER_AUX, threshold_mv=0)
+scope.set_trigger_channel_directions(
+    channel=psdk.CHANNEL.TRIGGER_AUX,
+    direction=psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING,
+    threshold_mode=psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
+)
+scope.set_trigger_channel_properties(0, 0, 0, 0, psdk.CHANNEL.TRIGGER_AUX)
 
 # Preferred: convert sample rate to timebase
 TIMEBASE = scope.sample_rate_to_timebase(50, psdk.SAMPLE_RATE.MSPS)

--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -789,13 +789,17 @@ class PicoScopeBase:
         state: int,
         action: int = ACTION.CLEAR_ALL | ACTION.ADD,
     ) -> None:
-        """Configure a trigger condition using ``SetTriggerChannelConditions``.
+        """Configure a trigger condition.
+
+        This wraps the PicoSDK ``SetTriggerChannelConditions`` call.  The
+        ``source`` channel is compared against ``state`` and combined with any
+        existing conditions according to ``action``.
 
         Args:
-            source: Input source for the condition as a :class:`CHANNEL` value.
-            state: Desired trigger state from :class:`PICO_TRIGGER_STATE`.
-            action: How to apply the condition relative to any existing
-                configuration. Defaults to ``ACTION.CLEAR_ALL | ACTION.ADD``.
+            source (int): Input source as a :class:`CHANNEL` value.
+            state (int): Desired state from :class:`PICO_TRIGGER_STATE`.
+            action (int, optional): How to apply this condition relative to any
+                previous configuration. Defaults to ``ACTION.CLEAR_ALL | ACTION.ADD``.
         """
 
         cond = PICO_CONDITION(source, state)
@@ -818,17 +822,20 @@ class PicoScopeBase:
         aux_output_enable: int = 0,
         auto_trigger_us: int = 0,
     ) -> None:
-        """Configure trigger thresholds using ``SetTriggerChannelProperties``.
+        """Configure trigger thresholds for ``channel``.
+
+        This method exposes the PicoSDK ``SetTriggerChannelProperties`` API. All
+        threshold and hysteresis values are specified in ADC counts.
 
         Args:
-            threshold_upper: ADC value for the upper trigger level.
-            hysteresis_upper: Hysteresis for ``threshold_upper`` in ADC counts.
-            threshold_lower: ADC value for the lower trigger level.
-            hysteresis_lower: Hysteresis for ``threshold_lower`` in ADC counts.
-            channel: Channel these settings apply to.
-            aux_output_enable: Optional auxiliary output flag.
-            auto_trigger_us: Auto-trigger timeout in microseconds. ``0`` waits
-                indefinitely.
+            threshold_upper (int): Upper trigger level.
+            hysteresis_upper (int): Hysteresis for ``threshold_upper``.
+            threshold_lower (int): Lower trigger level.
+            hysteresis_lower (int): Hysteresis for ``threshold_lower``.
+            channel (int): Target channel as a :class:`CHANNEL` value.
+            aux_output_enable (int, optional): Auxiliary output flag.
+            auto_trigger_us (int, optional): Auto-trigger timeout in
+                microseconds. ``0`` waits indefinitely.
         """
 
         prop = PICO_TRIGGER_CHANNEL_PROPERTIES(
@@ -854,13 +861,16 @@ class PicoScopeBase:
         direction: int,
         threshold_mode: int,
     ) -> None:
-        """Configure trigger directions using ``SetTriggerChannelDirections``.
+        """Specify the trigger direction for ``channel``.
+
+        This method mirrors the PicoSDK ``SetTriggerChannelDirections`` call.
 
         Args:
-            channel: Channel to apply the direction to.
-            direction: Desired trigger direction from
+            channel (int): Channel to configure.
+            direction (int): Direction value from
                 :class:`PICO_THRESHOLD_DIRECTION`.
-            threshold_mode: Threshold mode from :class:`PICO_THRESHOLD_MODE`.
+            threshold_mode (int): Threshold mode from
+                :class:`PICO_THRESHOLD_MODE`.
         """
 
         dir_struct = PICO_DIRECTION(channel, direction, threshold_mode)

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -451,10 +451,14 @@ class PICO_TRIGGER_CHANNEL_PROPERTIES(ctypes.Structure):
 
 
 class PICO_CONDITION(ctypes.Structure):
-    """Trigger condition structure used by ``SetTriggerChannelConditions``.
+    """Trigger condition used by ``SetTriggerChannelConditions``.
 
     Each instance defines the state that a particular input source must meet
     for the overall trigger to occur.
+
+    Attributes:
+        source_: Channel being monitored as a :class:`CHANNEL` value.
+        condition_: Desired state from :class:`PICO_TRIGGER_STATE`.
     """
 
     #: Ensure this structure matches the 1-byte packed layout used in the
@@ -497,7 +501,13 @@ class PICO_THRESHOLD_MODE(IntEnum):
 
 
 class PICO_DIRECTION(ctypes.Structure):
-    """Structure used by ``SetTriggerChannelDirections`` to specify trigger directions."""
+    """Direction descriptor for ``SetTriggerChannelDirections``.
+
+    Attributes:
+        channel_: Channel index as a :class:`CHANNEL` value.
+        direction_: Direction from :class:`PICO_THRESHOLD_DIRECTION`.
+        thresholdMode_: Threshold mode from :class:`PICO_THRESHOLD_MODE`.
+    """
 
     _pack_ = 1
 


### PR DESCRIPTION
## Summary
- clarify trigger condition, property, and direction docstrings
- document fields for `PICO_CONDITION` and `PICO_DIRECTION`
- demonstrate advanced trigger APIs in aux trigger example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba1fe91bc832797a3c5cb38c9e45d