### PR TITLE
Add TIMESTAMP_COUNTER_MASK constant and update docs

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -76,3 +76,5 @@ limitation.
 The `timeStampCounter` field of :class:`PICO_TRIGGER_INFO` lets you measure the delay between consecutive captures.
 See `examples/example_6000a_dead_time.py` for a script that performs a rapid block run,
 retrieves trigger information for each segment and plots the dead time between triggers.
+Use the :data:`pypicosdk.TIMESTAMP_COUNTER_MASK` constant to handle wrap around of the
+56-bit ``timeStampCounter`` field when calculating differences.

--- a/examples/example_6000a_dead_time.py
+++ b/examples/example_6000a_dead_time.py
@@ -32,11 +32,10 @@ scope.close_unit()
 
 # Calculate dead time between captures
 SAMPLE_INTERVAL_NS = time_axis[1] - time_axis[0]
-COUNTER_MASK = 0x00FFFFFFFFFFFFFF
 
 dead_times = []
 for prev, curr in zip(trigger_info[:-1], trigger_info[1:]):
-    diff_samples = (curr.timeStampCounter_ - prev.timeStampCounter_) & COUNTER_MASK
+    diff_samples = (curr.timeStampCounter_ - prev.timeStampCounter_) & psdk.TIMESTAMP_COUNTER_MASK
     dead_samples = diff_samples - SAMPLES
     dead_times.append(dead_samples * SAMPLE_INTERVAL_NS)
 

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -419,6 +419,9 @@ class PICO_TRIGGER_INFO(ctypes.Structure):
         ("timeStampCounter_", ctypes.c_uint64),
     ]
 
+TIMESTAMP_COUNTER_MASK: int = (1 << 56) - 1
+"""Mask for the 56-bit ``timeStampCounter`` field."""
+
 
 class PICO_TRIGGER_CHANNEL_PROPERTIES(ctypes.Structure):
     """Trigger threshold configuration for a single channel.
@@ -547,6 +550,7 @@ __all__ = [
     'PICO_STREAMING_DATA_INFO',
     'PICO_STREAMING_DATA_TRIGGER_INFO',
     'PICO_TRIGGER_INFO',
+    'TIMESTAMP_COUNTER_MASK',
     'PICO_TRIGGER_CHANNEL_PROPERTIES',
     'PICO_CONDITION',
     'PICO_THRESHOLD_DIRECTION',


### PR DESCRIPTION
## Summary
- add `TIMESTAMP_COUNTER_MASK` to `pypicosdk.constants`
- use new constant in dead time example
- document constant in ps6000a reference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bc40dcf8c83279680319889a92a9a