### PR TITLE
Overlay all captures in rapid block example

### DIFF
--- a/examples/example_6000a_rapid_block.py
+++ b/examples/example_6000a_rapid_block.py
@@ -29,8 +29,9 @@ buffers, time_axis = scope.run_simple_rapid_block_capture(
 
 scope.close_unit()
 
-# Plot the first capture as an example
-plt.plot(time_axis, buffers[psdk.CHANNEL.A][0])
+# Overlay all captures on a single plot
+for wf in buffers[psdk.CHANNEL.A]:
+    plt.plot(time_axis, wf, alpha=0.3)
 plt.xlabel("Time (ns)")
 plt.ylabel("Amplitude (mV)")
 plt.grid(True)


### PR DESCRIPTION
## Summary
- plot each capture from the rapid block run so they're overlaid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd00057248327879f1c6cfc4e3efc