### PR TITLE
Add plot range helper function

### DIFF
--- a/examples/example_6000a_siggen_block_capture.py
+++ b/examples/example_6000a_siggen_block_capture.py
@@ -33,8 +33,8 @@ scope.close_unit()
 plt.plot(time_axis, channel_buffer[channel_a])
 
 # Add labels to pyplot
-plt.xlabel("Time (ns)")     
+plt.xlabel("Time (ns)")
 plt.ylabel("Amplitude (mV)")
-plt.ylim(-500, 500)
+plt.ylim(*scope.get_plot_range())
 plt.grid(True)
 plt.show()

--- a/examples/example_6000a_simple_block_capture.py
+++ b/examples/example_6000a_simple_block_capture.py
@@ -28,9 +28,9 @@ plt.plot(time_axis, channel_buffer[channel_a], label='Channel A')
 plt.plot(time_axis, channel_buffer[channel_b], label='Channel B')
 
 # Add labels to pyplot
-plt.xlabel("Time (ns)")     
+plt.xlabel("Time (ns)")
 plt.ylabel("Amplitude (mV)")
-plt.ylim(-500, 500)
+plt.ylim(*scope.get_plot_range())
 plt.legend()
 plt.grid(True)
 plt.show()

--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -486,6 +486,13 @@ class PicoScopeBase:
             channels_buffer[channel] = self.buffer_ctypes_to_list(channels_buffer[channel])
         return channels_buffer
 
+    def get_plot_range(self) -> tuple:
+        """Return plot limits based on the widest enabled channel range."""
+        if not self.range:
+            raise PicoSDKException("No channels have been configured using set_channel()")
+        max_mv = max(RANGE_LIST[r] for r in self.range.values())
+        return -max_mv, max_mv
+
     # Set methods for PicoScope configuration    
     def _change_power_source(self, state: POWER_SOURCE) -> 0:
         """

--- a/tests/plot_range_test.py
+++ b/tests/plot_range_test.py
@@ -1,0 +1,14 @@
+import pypicosdk as psdk
+from pypicosdk import RANGE, CHANNEL
+
+
+def test_plot_range_single_channel():
+    scope = psdk.ps6000a('pytest')
+    scope.range = {CHANNEL.A: RANGE.V1}
+    assert scope.get_plot_range() == (-1000, 1000)
+
+
+def test_plot_range_multiple_channels():
+    scope = psdk.ps6000a('pytest')
+    scope.range = {CHANNEL.A: RANGE.V1, CHANNEL.B: RANGE.V10}
+    assert scope.get_plot_range() == (-10000, 10000)


### PR DESCRIPTION
## Summary
- add `get_plot_range` method to determine y limits for plotting
- update examples to use the helper
- add tests for the new method

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd9bf35788327959ead994eeca905