### PR TITLE
Enable numpy output for block capture

### DIFF
--- a/examples/example_6000a_fft.py
+++ b/examples/example_6000a_fft.py
@@ -46,14 +46,16 @@ scope.set_channel(channel=channel_a, range=range)
 scope.set_simple_trigger(channel=channel_a, threshold_mv=threshold)
 
 # Run the block capture
-channel_buffer, time_axis = scope.run_simple_block_capture(timebase, samples)
+channel_buffer, time_axis = scope.run_simple_block_capture(
+    timebase, samples, time_unit=psdk.TIME_UNIT.S
+)
 
 # Finish with PicoScope
 scope.close_unit()
 
-# Take out data (converting ns time axis to s)
+# Take out data; time axis already in seconds
 v = np.array(channel_buffer[channel_a])
-t = np.array(time_axis) * 1E-9
+t = np.array(time_axis)
 
 # Get sample rate
 dt = t[1] - t[0]

--- a/examples/example_6000a_pk2pk_histogram.py
+++ b/examples/example_6000a_pk2pk_histogram.py
@@ -49,7 +49,8 @@ for _ in range(nCaptures):
     # Simple block capture
     channel_buffer, time_axis = scope.run_simple_block_capture(
         timebase=scope.sample_rate_to_timebase(1.25, psdk.SAMPLE_RATE.MSPS),
-        samples=nSamples
+        samples=nSamples,
+        time_unit=psdk.TIME_UNIT.US,
     )
 
     # Add channel data to list
@@ -74,7 +75,7 @@ fig, axs = plt.subplots(2, 1, figsize=(10, 8))
 # Top subplot: Overlay of all waveforms
 for waveform in waveforms:
     axs[0].plot(time_axis, waveform, alpha=0.3)
-axs[0].set_xlabel("Time (ns)")
+axs[0].set_xlabel("Time (\u03bcs)")
 axs[0].set_ylabel("Amplitude (mV)")
 axs[0].set_title(f"Overlay of {nCaptures} Waveforms")
 axs[0].grid(True)

--- a/examples/example_6000a_siggen_block_capture.py
+++ b/examples/example_6000a_siggen_block_capture.py
@@ -24,7 +24,9 @@ scope.set_channel(channel=channel_a, range=range)
 scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
 
 # Run the block capture
-channel_buffer, time_axis = scope.run_simple_block_capture(timebase, samples)
+channel_buffer, time_axis = scope.run_simple_block_capture(
+    timebase, samples, time_unit=psdk.TIME_UNIT.US
+)
 
 # Finish with PicoScope
 scope.close_unit()
@@ -33,7 +35,7 @@ scope.close_unit()
 plt.plot(time_axis, channel_buffer[channel_a])
 
 # Add labels to pyplot
-plt.xlabel("Time (ns)")
+plt.xlabel("Time (\u03bcs)")
 plt.ylabel("Amplitude (mV)")
 plt.ylim(scope.get_plot_range())
 plt.grid(True)

--- a/examples/example_6000a_simple_block_capture.py
+++ b/examples/example_6000a_simple_block_capture.py
@@ -18,7 +18,9 @@ scope.set_channel(channel=channel_b, range=range)
 scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
 
 # Run the block capture
-channel_buffer, time_axis = scope.run_simple_block_capture(timebase, samples)
+channel_buffer, time_axis = scope.run_simple_block_capture(
+    timebase, samples, time_unit=psdk.TIME_UNIT.US
+)
 
 # Finish with PicoScope
 scope.close_unit()
@@ -28,7 +30,7 @@ plt.plot(time_axis, channel_buffer[channel_a], label='Channel A')
 plt.plot(time_axis, channel_buffer[channel_b], label='Channel B')
 
 # Add labels to pyplot
-plt.xlabel("Time (ns)")
+plt.xlabel("Time (\u03bcs)")
 plt.ylabel("Amplitude (mV)")
 plt.ylim(scope.get_plot_range())
 plt.legend()

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -1,6 +1,19 @@
 import ctypes
+import numpy as np
 from .base import PicoScopeBase
-from .constants import CHANNEL, RANGE, COUPLING, BANDWIDTH_CH, DATA_TYPE, RATIO_MODE, ACTION, WAVEFORM, TRIGGER_DIR, RESOLUTION
+from .constants import (
+    CHANNEL,
+    RANGE,
+    COUPLING,
+    BANDWIDTH_CH,
+    DATA_TYPE,
+    RATIO_MODE,
+    ACTION,
+    WAVEFORM,
+    TRIGGER_DIR,
+    RESOLUTION,
+    TIME_UNIT,
+)
 
 class ps6000a(PicoScopeBase):
     """PicoScope 6000 (A) API specific functions"""
@@ -133,8 +146,18 @@ class ps6000a(PicoScopeBase):
         self._siggen_set_duty_cycle(duty)
         return self._siggen_apply()
     
-    def run_simple_block_capture(self, timebase:int, samples:int, segment=0, start_index=0, datatype=DATA_TYPE.INT16_T, ratio=0, 
-                         ratio_mode=RATIO_MODE.RAW, pre_trig_percent=50) -> tuple[dict, list]:
+    def run_simple_block_capture(
+        self,
+        timebase: int,
+        samples: int,
+        segment: int = 0,
+        start_index: int = 0,
+        datatype: DATA_TYPE = DATA_TYPE.INT16_T,
+        ratio: int = 0,
+        ratio_mode: RATIO_MODE = RATIO_MODE.RAW,
+        pre_trig_percent: int = 50,
+        time_unit: TIME_UNIT | None = TIME_UNIT.NS,
+    ) -> tuple[dict, "np.ndarray"]:
         """
         Performs a complete single block capture using current channel and trigger configuration.
 
@@ -151,10 +174,12 @@ class ps6000a(PicoScopeBase):
             ratio (int, optional): Downsampling ratio.
             ratio_mode (RATIO_MODE, optional): Downsampling mode.
             pre_trig_percent (int, optional): Percentage of samples to capture before the trigger.
+            time_unit (TIME_UNIT | None, optional): Units for the returned time axis.
+                ``None`` selects a sensible unit automatically.
 
         Returns:
-            dict: A dictionary mapping each enabled channel to its corresponding data buffer.
-            list: Time axis (x-axis) list of timestamps for the sample data
+            dict: Mapping of each enabled channel to a numpy array of captured values in mV.
+            numpy.ndarray: Time axis (x-axis) of timestamps for the sample data.
 
         Examples:
             >>> scope.set_channel(CHANNEL.A, RANGE.V1)
@@ -170,10 +195,13 @@ class ps6000a(PicoScopeBase):
         # Get values from PicoScope (returning actual samples for time_axis)
         actual_samples = self.get_values(samples, start_index, segment, ratio, ratio_mode)
 
-        # Convert from ADC to mV values
-        channels_buffer = self.channels_buffer_adc_to_mv(channels_buffer)
+        # Convert from ADC to mV values and into numpy arrays
+        channels_buffer = {
+            ch: np.asarray(self.buffer_adc_to_mv(buf, ch), dtype=float)
+            for ch, buf in channels_buffer.items()
+        }
 
         # Generate the time axis based on actual samples and timebase
-        time_axis = self.get_time_axis(timebase, actual_samples)
+        time_axis = np.asarray(self.get_time_axis(timebase, actual_samples, time_unit), dtype=float)
 
         return channels_buffer, time_axis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "pypicosdk"
 dynamic = ["version"]
+dependencies = ["numpy"]
 keywords = [
     "test",
     "measurement",

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     package_data={
         "pypicosdk": extra_files,
     },
+    install_requires=["numpy"],
     author="Pico Technology",
     author_email="support@picotech.com",
     description="Modern Python wrapper for PicoSDK",

--- a/tests/time_axis_test.py
+++ b/tests/time_axis_test.py
@@ -1,0 +1,16 @@
+from pypicosdk import ps6000a, TIME_UNIT
+
+
+def test_get_time_axis_units():
+    scope = ps6000a('pytest')
+    # Patch get_timebase to return a fixed interval of 100 ns
+    scope.get_timebase = lambda tb, s: {'Interval(ns)': 100, 'Samples': s}
+
+    axis_ns = scope.get_time_axis(2, 3, TIME_UNIT.NS)
+    assert axis_ns.tolist() == [0.0, 100.0, 200.0]
+
+    axis_us = scope.get_time_axis(2, 3, TIME_UNIT.US)
+    assert axis_us.tolist() == [0.0, 0.1, 0.2]
+
+    axis_auto = scope.get_time_axis(2, 3, None)
+    assert axis_auto.tolist() == [0.0, 100.0, 200.0]


### PR DESCRIPTION
## Summary
- return numpy arrays from `get_time_axis`
- produce numpy buffers and time axis in `run_simple_block_capture`
- add numpy as a requirement
- allow specifying time units when retrieving time axis
- use the new `time_unit` parameter in example scripts

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686be41432088327a675089f1c463b8e