### PR TITLE
Enhance get_plot_range return type

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -3,6 +3,7 @@ import os
 import warnings
 import platform
 import numpy as np
+from dataclasses import dataclass
 
 from .error_list import ERROR_STRING
 from .constants import *
@@ -20,6 +21,23 @@ class OverrangeWarning(UserWarning):
 
 class PowerSupplyWarning(UserWarning):
     pass
+
+
+@dataclass
+class PlotRange:
+    """Container for plot limits and units."""
+
+    ylim: tuple
+    unit: str = "mV"
+
+    def __iter__(self):
+        return iter(self.ylim)
+
+    def __len__(self):
+        return len(self.ylim)
+
+    def __getitem__(self, index):
+        return self.ylim[index]
 
 
 # General Functions
@@ -508,12 +526,12 @@ class PicoScopeBase:
             channels_buffer[channel] = self.buffer_ctypes_to_list(channels_buffer[channel])
         return channels_buffer
 
-    def get_plot_range(self) -> tuple:
+    def get_plot_range(self) -> PlotRange:
         """Return plot limits based on the widest enabled channel range."""
         if not self.range:
             raise PicoSDKException("No channels have been configured using set_channel()")
         max_mv = max(RANGE_LIST[r] for r in self.range.values())
-        return -max_mv, max_mv
+        return PlotRange((-max_mv, max_mv))
 
     # Set methods for PicoScope configuration    
     def _change_power_source(self, state: POWER_SOURCE) -> 0:

--- a/tests/plot_range_test.py
+++ b/tests/plot_range_test.py
@@ -5,10 +5,15 @@ from pypicosdk import RANGE, CHANNEL
 def test_plot_range_single_channel():
     scope = psdk.ps6000a('pytest')
     scope.range = {CHANNEL.A: RANGE.V1}
-    assert scope.get_plot_range() == (-1000, 1000)
+    pr = scope.get_plot_range()
+    assert tuple(pr) == (-1000, 1000)
+    assert pr.ylim == (-1000, 1000)
+    assert pr.unit == "mV"
 
 
 def test_plot_range_multiple_channels():
     scope = psdk.ps6000a('pytest')
     scope.range = {CHANNEL.A: RANGE.V1, CHANNEL.B: RANGE.V10}
-    assert scope.get_plot_range() == (-10000, 10000)
+    pr = scope.get_plot_range()
+    assert tuple(pr) == (-10000, 10000)
+    assert pr.unit == "mV"


### PR DESCRIPTION
## Summary
- add `PlotRange` dataclass for convenient axis label info
- return `PlotRange` from `get_plot_range`
- update tests for new return object

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd49738148327a217f5125dd58551