### PR TITLE
Use NumPy arrays for data buffers

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -581,9 +581,9 @@ class PicoScopeBase:
         raise NotImplemented("Method not yet available for this oscilloscope")
     
     
-    def _set_data_buffer_ps6000a(self, channel, samples, segment=0, 
-                                 datatype=DATA_TYPE.INT16_T, ratio_mode=RATIO_MODE.RAW, 
-                                 action=ACTION.CLEAR_ALL | ACTION.ADD) -> ctypes.Array:
+    def _set_data_buffer_ps6000a(self, channel, samples, segment=0,
+                                 datatype=DATA_TYPE.INT16_T, ratio_mode=RATIO_MODE.RAW,
+                                 action=ACTION.CLEAR_ALL | ACTION.ADD):
         """
         Allocates and assigns a data buffer for a specified channel on the 6000A series.
 
@@ -596,25 +596,38 @@ class PicoScopeBase:
             action (ACTION, optional): Action to apply to the data buffer (e.g., CLEAR_ALL | ADD).
 
         Returns:
-            ctypes.Array: A ctypes array that will be populated with data during capture.
+            numpy.ndarray: A NumPy array that will be populated with data during
+                capture.
 
         Raises:
             PicoSDKException: If an unsupported data type is provided.
         """
-        if datatype == DATA_TYPE.INT8_T:     buffer = (ctypes.c_int8 * samples)
-        elif datatype == DATA_TYPE.INT16_T:  buffer = (ctypes.c_int16 * samples)
-        elif datatype == DATA_TYPE.INT32_T:  buffer = (ctypes.c_int32 * samples)
-        elif datatype == DATA_TYPE.INT64_T:  buffer = (ctypes.c_int64 * samples)
-        elif datatype == DATA_TYPE.UINT32_T: buffer = (ctypes.c_uint32 * samples)
-        else: raise PicoSDKException("Invalid datatype selected for buffer")
+        if datatype == DATA_TYPE.INT8_T:
+            dtype = np.int8
+            c_type = ctypes.c_int8
+        elif datatype == DATA_TYPE.INT16_T:
+            dtype = np.int16
+            c_type = ctypes.c_int16
+        elif datatype == DATA_TYPE.INT32_T:
+            dtype = np.int32
+            c_type = ctypes.c_int32
+        elif datatype == DATA_TYPE.INT64_T:
+            dtype = np.int64
+            c_type = ctypes.c_int64
+        elif datatype == DATA_TYPE.UINT32_T:
+            dtype = np.uint32
+            c_type = ctypes.c_uint32
+        else:
+            raise PicoSDKException("Invalid datatype selected for buffer")
 
-        buffer = buffer()
+        buffer = np.zeros(samples, dtype=dtype)
+        c_buffer = buffer.ctypes.data_as(ctypes.POINTER(c_type))
         
         self._call_attr_function(
             'SetDataBuffer',
             self.handle,
             channel,
-            ctypes.byref(buffer),
+            c_buffer,
             samples,
             datatype,
             segment,

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -84,8 +84,8 @@ class ps6000a(PicoScopeBase):
         auto_trigger_us = auto_trigger_ms * 1000
         return super().set_simple_trigger(channel, threshold_mv, enable, direction, delay, auto_trigger_us)
     
-    def set_data_buffer(self, channel:CHANNEL, samples:int, segment:int=0, datatype:DATA_TYPE=DATA_TYPE.INT16_T, 
-                        ratio_mode:RATIO_MODE=RATIO_MODE.RAW, action:ACTION=ACTION.CLEAR_ALL | ACTION.ADD) -> ctypes.Array:
+    def set_data_buffer(self, channel:CHANNEL, samples:int, segment:int=0, datatype:DATA_TYPE=DATA_TYPE.INT16_T,
+                        ratio_mode:RATIO_MODE=RATIO_MODE.RAW, action:ACTION = ACTION.CLEAR_ALL | ACTION.ADD):
         """
         Tells the driver where to store the data that will be populated when get_values() is called.
         This function works on a single buffer. For aggregation mode, call set_data_buffers instead.
@@ -99,11 +99,11 @@ class ps6000a(PicoScopeBase):
                 action (ACTION, optional): Method to use when creating a buffer.
 
         Returns:
-                ctypes.Array: Array that will be populated when get_values() is called.
+                numpy.ndarray: Array that will be populated when get_values() is called.
         """
         return super()._set_data_buffer_ps6000a(channel, samples, segment, datatype, ratio_mode, action)
     
-    def set_data_buffer_for_enabled_channels(self, samples:int, segment:int=0, datatype=DATA_TYPE.INT16_T, 
+    def set_data_buffer_for_enabled_channels(self, samples:int, segment:int=0, datatype=DATA_TYPE.INT16_T,
                                              ratio_mode=RATIO_MODE.RAW) -> dict:
         """
         Sets data buffers for enabled channels set by picosdk.set_channel()
@@ -115,7 +115,7 @@ class ps6000a(PicoScopeBase):
             ratio_mode (RATIO_MODE): The ratio mode (e.g., RAW, AVERAGE).
 
         Returns:
-            dict: A dictionary mapping each channel to its associated data buffer.
+            dict: A dictionary mapping each channel to its associated NumPy array buffer.
         """
         # Clear the buffer
         super()._set_data_buffer_ps6000a(0, 0, 0, 0, 0, ACTION.CLEAR_ALL)
@@ -158,7 +158,7 @@ class ps6000a(PicoScopeBase):
         pre_trig_percent: int = 50,
         time_unit: TIME_UNIT | None = TIME_UNIT.NS,
     ) -> tuple[dict, "np.ndarray"]:
-        Performs a complete single block capture using current channel and trigger configuration.
+        """Performs a complete single block capture using current channel and trigger configuration.
 
         This function sets up data buffers for all enabled channels, starts a block capture,
         and retrieves the values once the device is ready. It is a simplified interface 

--- a/tests/data_buffer_test.py
+++ b/tests/data_buffer_test.py
@@ -1,0 +1,21 @@
+import numpy as np
+from pypicosdk import ps6000a, CHANNEL, RANGE
+
+
+def test_set_data_buffer_returns_numpy(monkeypatch):
+    scope = ps6000a("pytest")
+    scope.range = {CHANNEL.A: RANGE.V1}
+    monkeypatch.setattr(scope, "_call_attr_function", lambda *a, **k: 0)
+    buf = scope.set_data_buffer(CHANNEL.A, 10)
+    assert isinstance(buf, np.ndarray)
+    assert buf.dtype == np.int16
+    assert buf.size == 10
+
+
+def test_set_data_buffer_for_enabled_channels_returns_numpy(monkeypatch):
+    scope = ps6000a("pytest")
+    scope.range = {CHANNEL.A: RANGE.V1, CHANNEL.B: RANGE.V1}
+    monkeypatch.setattr(scope, "_call_attr_function", lambda *a, **k: 0)
+    buffers = scope.set_data_buffer_for_enabled_channels(5)
+    assert set(buffers.keys()) == {CHANNEL.A, CHANNEL.B}
+    assert all(isinstance(b, np.ndarray) for b in buffers.values())


### PR DESCRIPTION
## Summary
- switch `_set_data_buffer_ps6000a` to allocate NumPy arrays
- update ps6000a set_data_buffer API documentation
- tests for NumPy buffer allocation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cdbc9db6c83278a37536c7bd2eee7