### PR TITLE
Define explicit public API lists

### DIFF
--- a/pypicosdk/__init__.py
+++ b/pypicosdk/__init__.py
@@ -1,1 +1,9 @@
+from . import base as _base
+from . import ps6000a as _ps6000a
+from . import pypicosdk as _pypicosdk
+
+from .base import *
+from .ps6000a import *
 from .pypicosdk import *
+
+__all__ = _base.__all__ + _ps6000a.__all__ + _pypicosdk.__all__

--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -846,3 +846,31 @@ class PicoScopeBase:
         raise NotImplementedError("Method not yet available for this oscilloscope")
 
 
+# Public API exports
+__all__ = [
+    "PicoSDKNotFoundException",
+    "PicoSDKException",
+    "OverrangeWarning",
+    "PowerSupplyWarning",
+    "PicoScopeBase",
+    "UNIT_INFO",
+    "RESOLUTION",
+    "TRIGGER_DIR",
+    "WAVEFORM",
+    "CHANNEL",
+    "CHANNEL_NAMES",
+    "COUPLING",
+    "RANGE",
+    "RANGE_LIST",
+    "BANDWIDTH_CH",
+    "DATA_TYPE",
+    "ACTION",
+    "RATIO_MODE",
+    "POWER_SOURCE",
+    "SAMPLE_RATE",
+    "TIME_UNIT",
+    "PICO_TIME_UNIT",
+    "VERSION",
+]
+
+

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -204,3 +204,7 @@ class ps6000a(PicoScopeBase):
         time_axis = np.asarray(self.get_time_axis(timebase, actual_samples, time_unit), dtype=float)
 
         return channels_buffer, time_axis
+
+
+# Public API exports for this module
+__all__ = ["ps6000a"]

--- a/pypicosdk/pypicosdk.py
+++ b/pypicosdk/pypicosdk.py
@@ -1,5 +1,7 @@
+from . import base as _base
+from . import ps6000a as _ps6000a
 from .base import *
-from .ps6000a import ps6000a
+from .ps6000a import *
 
 
 def get_all_enumerated_units() -> tuple[int, list[str]]:
@@ -11,4 +13,8 @@ def get_all_enumerated_units() -> tuple[int, list[str]]:
         n_units += units[0]
         unit_serial += units[1].split(',')
     return n_units, unit_serial
+
+
+# Public API exports for this module
+__all__ = _base.__all__ + _ps6000a.__all__ + ["get_all_enumerated_units"]
 


### PR DESCRIPTION
## Summary
- declare exported names in `base.py`, `ps6000a.py` and `pypicosdk.py`
- re-export module APIs via `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce3e07ea48327ab8d242006dff7b5