### PR TITLE
Refactor constants to IntEnum

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -130,7 +130,7 @@ class PicoScopeBase:
         return status
 
     # General PicoSDK functions    
-    def _open_unit(self, serial_number:int=None, resolution:RESOLUTION=0) -> None:
+    def _open_unit(self, serial_number: int | None = None, resolution: RESOLUTION = RESOLUTION._8BIT) -> None:
         """
         Opens PicoScope unit.
 

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 
-class UNIT_INFO:
+class UNIT_INFO(IntEnum):
     """
     Unit information identifiers for querying PicoScope device details.
 
@@ -34,7 +34,7 @@ class UNIT_INFO:
     PICO_FIRMWARE_VERSION_1 = 9
     PICO_FIRMWARE_VERSION_2 = 10
 
-class RESOLUTION:
+class RESOLUTION(IntEnum):
     """
     Resolution constants for PicoScope devices.
 
@@ -58,7 +58,7 @@ class RESOLUTION:
     _15BIT = 3
     _16BIT = 4
 
-class TRIGGER_DIR:
+class TRIGGER_DIR(IntEnum):
     """
     Trigger direction constants for configuring PicoScope triggers.
 
@@ -75,7 +75,7 @@ class TRIGGER_DIR:
     FALLING = 3
     RISING_OR_FALLING = 4
 
-class WAVEFORM:    
+class WAVEFORM(IntEnum):
     """
     Waveform type constants for PicoScope signal generator configuration.
 

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -21,7 +21,7 @@ class ps6000a(PicoScopeBase):
         super().__init__("ps6000a", *args, **kwargs)
 
 
-    def open_unit(self, serial_number:str=None, resolution:RESOLUTION = 0) -> None:
+    def open_unit(self, serial_number: str | None = None, resolution: RESOLUTION = RESOLUTION._8BIT) -> None:
         """
         Open PicoScope unit.
 


### PR DESCRIPTION
## Summary
- change UNIT_INFO, RESOLUTION, TRIGGER_DIR and WAVEFORM to IntEnum
- set open_unit default resolution using RESOLUTION enum

## Testing
- `pip install numpy pytest`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce41de9048327a5dbf7334367c997