### PR TITLE
Add memory management functions

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -500,6 +500,63 @@ class PicoScopeBase:
         )
         return time.value
 
+    def memory_segments(self, n_segments: int) -> int:
+        """Configure the number of memory segments on the device.
+
+        Args:
+            n_segments (int): Desired number of memory segments.
+
+        Returns:
+            int: Maximum number of samples available per segment.
+        """
+        max_samples = ctypes.c_uint64()
+        self._call_attr_function(
+            "MemorySegments",
+            self.handle,
+            ctypes.c_uint64(n_segments),
+            ctypes.byref(max_samples),
+        )
+        return max_samples.value
+
+    def memory_segments_by_samples(self, n_samples: int) -> int:
+        """Divide memory so each segment holds ``n_samples`` samples.
+
+        Args:
+            n_samples (int): Number of samples required per segment.
+
+        Returns:
+            int: Number of segments created by the driver.
+        """
+        max_segments = ctypes.c_uint64()
+        self._call_attr_function(
+            "MemorySegmentsBySamples",
+            self.handle,
+            ctypes.c_uint64(n_samples),
+            ctypes.byref(max_segments),
+        )
+        return max_segments.value
+
+    def query_max_segments_by_samples(self, n_samples: int, n_channel_enabled: int) -> int:
+        """Query the maximum segments available for a capture setup.
+
+        Args:
+            n_samples (int): Number of samples per segment.
+            n_channel_enabled (int): Number of channels enabled.
+
+        Returns:
+            int: Maximum number of segments supported.
+        """
+        max_segments = ctypes.c_uint64()
+        self._call_attr_function(
+            "QueryMaxSegmentsBySamples",
+            self.handle,
+            ctypes.c_uint64(n_samples),
+            ctypes.c_uint32(n_channel_enabled),
+            ctypes.byref(max_segments),
+            self.resolution,
+        )
+        return max_segments.value
+
 
     
     # Data conversion ADC/mV & ctypes/int 

--- a/tests/memory_segments_test.py
+++ b/tests/memory_segments_test.py
@@ -1,0 +1,41 @@
+import ctypes
+from pypicosdk import ps6000a, RESOLUTION
+
+
+def test_memory_segments(monkeypatch):
+    scope = ps6000a("pytest")
+    scope.resolution = RESOLUTION._8BIT
+
+    def fake_call(name, *args):
+        ptr = ctypes.cast(args[2], ctypes.POINTER(ctypes.c_uint64))
+        ptr.contents.value = 123
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    assert scope.memory_segments(10) == 123
+
+
+def test_memory_segments_by_samples(monkeypatch):
+    scope = ps6000a("pytest")
+    scope.resolution = RESOLUTION._8BIT
+
+    def fake_call(name, *args):
+        ptr = ctypes.cast(args[2], ctypes.POINTER(ctypes.c_uint64))
+        ptr.contents.value = 5
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    assert scope.memory_segments_by_samples(1000) == 5
+
+
+def test_query_max_segments_by_samples(monkeypatch):
+    scope = ps6000a("pytest")
+    scope.resolution = RESOLUTION._8BIT
+
+    def fake_call(name, *args):
+        ptr = ctypes.cast(args[3], ctypes.POINTER(ctypes.c_uint64))
+        ptr.contents.value = 8
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    assert scope.query_max_segments_by_samples(1000, 2) == 8


### PR DESCRIPTION
## Summary
- implement memory segment management methods in `PicoScopeBase`
- add unit tests for new functions
- install project in editable mode for testing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cede3009883278b68b7043318de13