### PR TITLE
Add advanced trigger example

### DIFF
--- a/docs/docs/ref/ps6000a.md
+++ b/docs/docs/ref/ps6000a.md
@@ -10,6 +10,28 @@ scope.open_unit()
 scope.close_unit()
 ```
 
+## Advanced Trigger Example
+Configure complex trigger conditions using `set_advanced_trigger()`.
+
+```python
+import pypicosdk as psdk
+
+scope = psdk.ps6000a()
+scope.open_unit()
+scope.set_advanced_trigger(
+    channel=psdk.CHANNEL.TRIGGER_AUX,
+    state=psdk.PICO_TRIGGER_STATE.TRUE,
+    direction=psdk.PICO_THRESHOLD_DIRECTION.PICO_RISING,
+    threshold_mode=psdk.PICO_THRESHOLD_MODE.PICO_LEVEL,
+    threshold_upper_mv=0,
+    threshold_lower_mv=0,
+)
+scope.close_unit()
+```
+
+See `examples/example_6000a_aux_advanced_trigger_block.py` for a full
+usage demonstration.
+
 ## Reference
 ::: pypicosdk.pypicosdk.ps6000a
     options:


### PR DESCRIPTION
## Summary
- document set_advanced_trigger in ps6000a reference
- provide short code snippet and point to the auxiliary example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf42d1b9083278f018a3ac1a354b7