### PR TITLE
Add timebase options to examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,5 +44,14 @@
 ## Examples
 - Example scripts pass argument values inline when calling API functions. This
   keeps each call self-contained and highlights the parameters in use.
+- When configuring a capture timebase, examples include three commented options:
+  ```python
+  TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                           unit=psdk.SAMPLE_RATE.MSPS)
+  # TIMEBASE = 2  # direct driver timebase
+  # TIMEBASE = scope.interval_to_timebase(20E-9)
+  ```
+  The first form using `sample_rate_to_timebase` with `SAMPLE_RATE.MSPS` is the
+  preferred option.
 
 Following these conventions keeps new constants and structures consistent with the existing definitions in `pypicosdk/constants.py`.

--- a/examples/example_6000a_advanced_block_capture.py
+++ b/examples/example_6000a_advanced_block_capture.py
@@ -8,7 +8,6 @@ import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
 # Setup variables
-timebase = 2
 samples = 100000
 channel = psdk.CHANNEL.A
 range = psdk.RANGE.V1
@@ -18,13 +17,19 @@ scope = psdk.ps6000a()
 scope.open_unit()
 print(scope.get_unit_serial())
 
+# Set capture timebase
+TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                         unit=psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+
 # Setup channels and trigger
 scope.set_channel(channel=channel, range=range)
 scope.set_simple_trigger(channel=channel, threshold_mv=0) 
 
 # Run block capture and retrieve values
 channels_buffer = scope.set_data_buffer_for_enabled_channels(samples=samples)
-scope.run_block_capture(timebase=timebase, samples=samples)
+scope.run_block_capture(timebase=TIMEBASE, samples=samples)
 scope.get_values(samples)
 
 # No ADC to mV conversion, add it here

--- a/examples/example_6000a_fft.py
+++ b/examples/example_6000a_fft.py
@@ -23,7 +23,6 @@ from scipy.fft import rfft, rfftfreq
 from scipy.signal import windows
 
 # Setup variables
-timebase = 3
 samples = 5_000_000
 channel_a = psdk.CHANNEL.A
 range = psdk.RANGE.V1
@@ -38,6 +37,12 @@ wave_type = psdk.WAVEFORM.SQUARE
 scope = psdk.ps6000a()
 scope.open_unit()
 
+# Set capture timebase
+TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                         unit=psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+
 # Setup siggen
 scope.set_siggen(frequency, pk2pk, wave_type)
 
@@ -47,7 +52,7 @@ scope.set_simple_trigger(channel=channel_a, threshold_mv=threshold)
 
 # Run the block capture
 channel_buffer, time_axis = scope.run_simple_block_capture(
-    timebase, samples, time_unit=psdk.TIME_UNIT.S
+    TIMEBASE, samples, time_unit=psdk.TIME_UNIT.S
 )
 
 # Finish with PicoScope

--- a/examples/example_6000a_pk2pk_histogram.py
+++ b/examples/example_6000a_pk2pk_histogram.py
@@ -25,6 +25,12 @@ import numpy as np
 scope = psdk.ps6000a()
 scope.open_unit(resolution=psdk.RESOLUTION._12BIT)
 
+# Set capture timebase
+TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                         unit=psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+
 # Set channels
 channel = psdk.CHANNEL.A
 
@@ -48,7 +54,7 @@ waveforms = []  # Store each waveform
 for _ in range(nCaptures):
     # Simple block capture
     channel_buffer, time_axis = scope.run_simple_block_capture(
-        timebase=scope.sample_rate_to_timebase(1.25, psdk.SAMPLE_RATE.MSPS),
+        timebase=TIMEBASE,
         samples=nSamples,
         time_unit=psdk.TIME_UNIT.US,
     )

--- a/examples/example_6000a_siggen.py
+++ b/examples/example_6000a_siggen.py
@@ -8,6 +8,12 @@ wave_type = psdk.WAVEFORM.SINE
 
 scope.open_unit()
 
+# Set capture timebase
+TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                         unit=psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+
 scope.set_siggen(frequency_hz, voltage_pk2pk, wave_type)
 input("Return to continue... ")
 

--- a/examples/example_6000a_siggen_block_capture.py
+++ b/examples/example_6000a_siggen_block_capture.py
@@ -2,7 +2,6 @@ import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
 # Setup variables
-timebase = 2
 samples = 50_000
 channel_a = psdk.CHANNEL.A
 range = psdk.RANGE.V1
@@ -16,6 +15,12 @@ wave_type = psdk.WAVEFORM.SINE
 scope = psdk.ps6000a()
 scope.open_unit()
 
+# Set capture timebase
+TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                         unit=psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+
 # Setup siggen
 scope.set_siggen(frequency, pk2pk, wave_type)
 
@@ -25,7 +30,7 @@ scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
 
 # Run the block capture
 channel_buffer, time_axis = scope.run_simple_block_capture(
-    timebase, samples, time_unit=psdk.TIME_UNIT.US
+    TIMEBASE, samples, time_unit=psdk.TIME_UNIT.US
 )
 
 # Finish with PicoScope

--- a/examples/example_6000a_simple_block_capture.py
+++ b/examples/example_6000a_simple_block_capture.py
@@ -2,7 +2,6 @@ import pypicosdk as psdk
 from matplotlib import pyplot as plt
 
 # Setup variables
-timebase = 2
 samples = 50_000
 channel_a = psdk.CHANNEL.A
 channel_b = psdk.CHANNEL.B
@@ -12,6 +11,12 @@ range = psdk.RANGE.V1
 scope = psdk.ps6000a()
 scope.open_unit()
 
+# Set capture timebase
+TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                         unit=psdk.SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+
 # Setup channels and trigger
 scope.set_channel(channel=channel_a, range=range)
 scope.set_channel(channel=channel_b, range=range)
@@ -19,7 +24,7 @@ scope.set_simple_trigger(channel=channel_a, threshold_mv=0)
 
 # Run the block capture
 channel_buffer, time_axis = scope.run_simple_block_capture(
-    timebase, samples, time_unit=psdk.TIME_UNIT.US
+    TIMEBASE, samples, time_unit=psdk.TIME_UNIT.US
 )
 
 # Finish with PicoScope

--- a/examples/example_6000a_timebase.py
+++ b/examples/example_6000a_timebase.py
@@ -10,6 +10,12 @@ interval_s = 10E-9 # 10 us
 scope = ps6000a()
 scope.open_unit()
 
+# Set capture timebase
+TIMEBASE = scope.sample_rate_to_timebase(sample_rate=500,
+                                         unit=SAMPLE_RATE.MSPS)
+# TIMEBASE = 2  # direct driver timebase
+# TIMEBASE = scope.interval_to_timebase(20E-9)
+
 # Setup channels to make sure sample interval is accurate
 scope.set_channel(CHANNEL.A, RANGE.V1)
 scope.set_channel(CHANNEL.C, RANGE.mV100)


### PR DESCRIPTION
## Summary
- add instructions for timebase options in AGENTS.md
- showcase three ways to set `TIMEBASE` across all PicoScope examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf87903b08327b91ddbbc29060e44