### PR TITLE
Add advanced trigger helpers

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+import ctypes
 
 class UNIT_INFO(IntEnum):
     """
@@ -74,6 +75,124 @@ class TRIGGER_DIR(IntEnum):
     RISING = 2
     FALLING = 3
     RISING_OR_FALLING = 4
+
+class TRIGGER_STATE(IntEnum):
+    """Trigger state used in advanced trigger conditions.
+
+    Attributes:
+        DONT_CARE: Ignore this channel when evaluating the condition.
+        TRUE: Condition must be true for the channel.
+        FALSE: Condition must be false for the channel.
+    """
+
+    DONT_CARE = 0
+    TRUE = 1
+    FALSE = 2
+
+class THRESHOLD_MODE(IntEnum):
+    """Threshold evaluation mode for trigger directions.
+
+    Attributes:
+        LEVEL: Use a single threshold level.
+        WINDOW: Use both upper and lower threshold values.
+    """
+
+    LEVEL = 0
+    WINDOW = 1
+
+class THRESHOLD_DIRECTION(IntEnum):
+    """Direction for threshold-based triggering.
+
+    Attributes:
+        ABOVE: Trigger when the signal is above the upper threshold.
+        BELOW: Trigger when the signal is below the lower threshold.
+        RISING: Trigger on a rising edge crossing the upper threshold.
+        FALLING: Trigger on a falling edge crossing the upper threshold.
+        RISING_OR_FALLING: Trigger on either rising or falling edge.
+        ABOVE_LOWER: Trigger when the signal is above the lower threshold.
+        BELOW_LOWER: Trigger when the signal is below the lower threshold.
+        RISING_LOWER: Trigger on a rising edge crossing the lower threshold.
+        FALLING_LOWER: Trigger on a falling edge crossing the lower threshold.
+        INSIDE: Trigger when the signal is inside the window.
+        OUTSIDE: Trigger when the signal is outside the window.
+        ENTER: Trigger when the signal enters the window.
+        EXIT: Trigger when the signal exits the window.
+        ENTER_OR_EXIT: Trigger when the signal enters or exits the window.
+        POSITIVE_RUNT: Trigger on a positive runt pulse.
+        NEGATIVE_RUNT: Trigger on a negative runt pulse.
+        NONE: Disable triggering for the channel.
+    """
+
+    ABOVE = 0
+    BELOW = 1
+    RISING = 2
+    FALLING = 3
+    RISING_OR_FALLING = 4
+    ABOVE_LOWER = 5
+    BELOW_LOWER = 6
+    RISING_LOWER = 7
+    FALLING_LOWER = 8
+    INSIDE = ABOVE
+    OUTSIDE = BELOW
+    ENTER = RISING
+    EXIT = FALLING
+    ENTER_OR_EXIT = RISING_OR_FALLING
+    POSITIVE_RUNT = 9
+    NEGATIVE_RUNT = 10
+    NONE = RISING
+
+class CONDITIONS_INFO(IntEnum):
+    """Actions when configuring multiple trigger conditions.
+
+    Attributes:
+        CLEAR_CONDITIONS: Clear any existing conditions before applying new ones.
+        ADD_CONDITION: Add the specified condition to any existing configuration.
+    """
+
+    CLEAR_CONDITIONS = 0x00000001
+    ADD_CONDITION = 0x00000002
+
+
+class TRIGGER_CHANNEL_PROPERTIES(ctypes.Structure):
+    """Threshold limits for a trigger channel.
+
+    Attributes:
+        thresholdUpper_: Upper threshold value in ADC counts.
+        thresholdUpperHysteresis_: Hysteresis for the upper threshold in ADC counts.
+        thresholdLower_: Lower threshold value in ADC counts.
+        thresholdLowerHysteresis_: Hysteresis for the lower threshold in ADC counts.
+        channel_: Channel this configuration applies to.
+    """
+
+    _pack_ = 1
+    _fields_ = [
+        ("thresholdUpper_", ctypes.c_int16),
+        ("thresholdUpperHysteresis_", ctypes.c_uint16),
+        ("thresholdLower_", ctypes.c_int16),
+        ("thresholdLowerHysteresis_", ctypes.c_uint16),
+        ("channel_", ctypes.c_int32),
+    ]
+
+
+class CONDITION(ctypes.Structure):
+    """Trigger condition for a specific channel."""
+
+    _pack_ = 1
+    _fields_ = [
+        ("source_", ctypes.c_int32),
+        ("condition_", ctypes.c_int32),
+    ]
+
+
+class DIRECTION(ctypes.Structure):
+    """Trigger direction for a channel."""
+
+    _pack_ = 1
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("direction_", ctypes.c_int32),
+        ("thresholdMode_", ctypes.c_int32),
+    ]
 
 class WAVEFORM(IntEnum):
     """
@@ -308,6 +427,13 @@ __all__ = [
     "SAMPLE_RATE",
     "TIME_UNIT",
     "TRIGGER_DIR",
+    "TRIGGER_STATE",
+    "THRESHOLD_MODE",
+    "THRESHOLD_DIRECTION",
+    "CONDITIONS_INFO",
+    "TRIGGER_CHANNEL_PROPERTIES",
+    "CONDITION",
+    "DIRECTION",
     "UNIT_INFO",
     "WAVEFORM",
 ]

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -11,6 +11,10 @@ from .constants import (
     ACTION,
     WAVEFORM,
     TRIGGER_DIR,
+    TRIGGER_STATE,
+    THRESHOLD_MODE,
+    THRESHOLD_DIRECTION,
+    CONDITIONS_INFO,
     RESOLUTION,
     TIME_UNIT,
 )
@@ -84,6 +88,18 @@ class ps6000a(PicoScopeBase):
         """
         auto_trigger_us = auto_trigger_ms * 1000
         return super().set_simple_trigger(channel, threshold_mv, enable, direction, delay, auto_trigger_us)
+
+    def set_trigger_channel_properties(self, properties, aux_output_enable=0, auto_trigger_ms=0):
+        """Wrapper converting auto-trigger from ms to µs."""
+
+        auto_trigger_us = auto_trigger_ms * 1000
+        return super().set_trigger_channel_properties(properties, aux_output_enable, auto_trigger_us)
+
+    def set_advanced_trigger(self, properties, directions, conditions, aux_output_enable=0, auto_trigger_ms=0, action=CONDITIONS_INFO.CLEAR_CONDITIONS | CONDITIONS_INFO.ADD_CONDITION):
+        """Configure an advanced trigger using millisecond units."""
+
+        auto_trigger_us = auto_trigger_ms * 1000
+        super().set_advanced_trigger(properties, directions, conditions, aux_output_enable, auto_trigger_us, action)
     
     def set_data_buffer(self, channel:CHANNEL, samples:int, segment:int=0, datatype:DATA_TYPE=DATA_TYPE.INT16_T,
                         ratio_mode:RATIO_MODE=RATIO_MODE.RAW, action:ACTION = ACTION.CLEAR_ALL | ACTION.ADD):

--- a/tests/advanced_trigger_test.py
+++ b/tests/advanced_trigger_test.py
@@ -1,0 +1,92 @@
+import ctypes
+from pypicosdk import (
+    ps6000a,
+    CHANNEL,
+    RANGE,
+    TRIGGER_STATE,
+    THRESHOLD_DIRECTION,
+    THRESHOLD_MODE,
+    TRIGGER_CHANNEL_PROPERTIES,
+    DIRECTION,
+    CONDITION,
+)
+
+
+def test_set_trigger_channel_properties(monkeypatch):
+    scope = ps6000a("pytest")
+    scope.range = {CHANNEL.A: RANGE.V1}
+    scope.max_adc_value = 32000
+
+    captured = {}
+
+    def fake_call(name, handle, props, n_props, aux, auto_us):
+        captured["name"] = name
+        arr = ctypes.cast(props, ctypes.POINTER(TRIGGER_CHANNEL_PROPERTIES))
+        captured["upper"] = arr.contents.thresholdUpper_
+        captured["channel"] = arr.contents.channel_
+        captured["auto"] = auto_us
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    scope.set_trigger_channel_properties([
+        {
+            "channel": CHANNEL.A,
+            "threshold_upper": 500.0,
+            "threshold_lower": -500.0,
+            "threshold_upper_hysteresis": 0.0,
+            "threshold_lower_hysteresis": 0.0,
+        }
+    ], auto_trigger_ms=1)
+
+    assert captured["name"] == "SetTriggerChannelProperties"
+    assert captured["channel"] == CHANNEL.A
+    assert captured["auto"] == 1000
+    assert captured["upper"] == scope.mv_to_adc(500.0, RANGE.V1)
+
+
+def test_set_trigger_channel_directions(monkeypatch):
+    scope = ps6000a("pytest")
+    captured = {}
+
+    def fake_call(name, handle, dirs, n_dirs):
+        captured["name"] = name
+        arr = ctypes.cast(dirs, ctypes.POINTER(DIRECTION))
+        captured["direction"] = arr.contents.direction_
+        captured["mode"] = arr.contents.thresholdMode_
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    scope.set_trigger_channel_directions({CHANNEL.A: (THRESHOLD_DIRECTION.RISING, THRESHOLD_MODE.LEVEL)})
+
+    assert captured["name"] == "SetTriggerChannelDirections"
+    assert captured["direction"] == THRESHOLD_DIRECTION.RISING
+    assert captured["mode"] == THRESHOLD_MODE.LEVEL
+
+
+def test_set_trigger_channel_conditions(monkeypatch):
+    scope = ps6000a("pytest")
+    captured = {}
+
+    def fake_call(name, handle, conds, n_conds, action):
+        captured["name"] = name
+        arr = ctypes.cast(conds, ctypes.POINTER(CONDITION))
+        captured["state"] = arr.contents.condition_
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    scope.set_trigger_channel_conditions({CHANNEL.A: TRIGGER_STATE.TRUE})
+
+    assert captured["name"] == "SetTriggerChannelConditions"
+    assert captured["state"] == TRIGGER_STATE.TRUE
+
+
+def test_set_advanced_trigger(monkeypatch):
+    scope = ps6000a("pytest")
+    called = {"prop": False, "dir": False, "cond": False}
+
+    monkeypatch.setattr(scope, "set_trigger_channel_properties", lambda *a, **k: called.__setitem__("prop", True))
+    monkeypatch.setattr(scope, "set_trigger_channel_directions", lambda *a, **k: called.__setitem__("dir", True))
+    monkeypatch.setattr(scope, "set_trigger_channel_conditions", lambda *a, **k: called.__setitem__("cond", True))
+
+    scope.set_advanced_trigger([], {}, {})
+    assert all(called.values())


### PR DESCRIPTION
## Summary
- add trigger data structures and enums to constants
- implement advanced trigger configuration APIs
- expose helpers in ps6000a
- add tests for trigger helpers

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfb7365fc832798fc26e4bba2c7a2