### PR TITLE
Add digital port and aux IO configuration

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -1277,6 +1277,9 @@ __all__ = [
     "SAMPLE_RATE",
     "TIME_UNIT",
     "PICO_TIME_UNIT",
+    "DIGITAL_PORT",
+    "DIGITAL_PORT_HYSTERESIS",
+    "AUX_IO_MODE",
     "VERSION",
 ]
 

--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -427,6 +427,30 @@ class PICO_TIME_UNIT(IntEnum):
     MS = 4
     S = 5
 
+class DIGITAL_PORT(IntEnum):
+    """Digital port identifier constants."""
+
+    PORT0 = 128
+    PORT1 = 129
+    PORT2 = 130
+    PORT3 = 131
+
+class DIGITAL_PORT_HYSTERESIS(IntEnum):
+    """Hysteresis levels for digital port thresholds."""
+
+    VERY_HIGH_400MV = 0
+    HIGH_200MV = 1
+    NORMAL_100MV = 2
+    LOW_50MV = 3
+
+class AUX_IO_MODE(IntEnum):
+    """Modes for the auxiliary I/O connector."""
+
+    INPUT = 0
+    HIGH_OUT = 1
+    LOW_OUT = 2
+    TRIGGER_OUT = 3
+
 __all__ = [
     "ACTION",
     "BANDWIDTH_CH",
@@ -453,4 +477,7 @@ __all__ = [
     "PICO_TRIGGER_INFO",
     "UNIT_INFO",
     "WAVEFORM",
+    "DIGITAL_PORT",
+    "DIGITAL_PORT_HYSTERESIS",
+    "AUX_IO_MODE",
 ]

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -17,6 +17,9 @@ from .constants import (
     CONDITIONS_INFO,
     RESOLUTION,
     TIME_UNIT,
+    DIGITAL_PORT,
+    DIGITAL_PORT_HYSTERESIS,
+    AUX_IO_MODE,
 )
 
 class ps6000a(PicoScopeBase):
@@ -53,7 +56,7 @@ class ps6000a(PicoScopeBase):
 
         return super()._get_timebase(timebase, samples, segment)
     
-    def set_channel(self, channel:CHANNEL, range:RANGE, enabled=True, coupling:COUPLING=COUPLING.DC, 
+    def set_channel(self, channel:CHANNEL, range:RANGE, enabled=True, coupling:COUPLING=COUPLING.DC,
                     offset:float=0.0, bandwidth=BANDWIDTH_CH.FULL) -> None:
         """
         Enable/disable a channel and specify certain variables i.e. range, coupling, offset, etc.
@@ -73,6 +76,49 @@ class ps6000a(PicoScopeBase):
             super()._set_channel_on(channel, range, coupling, offset, bandwidth)
         else:
             super()._set_channel_off(channel)
+
+    def set_digital_port_on(
+        self,
+        port: DIGITAL_PORT,
+        logic_threshold_level: list[int],
+        hysteresis: DIGITAL_PORT_HYSTERESIS,
+    ) -> None:
+        """Enable a digital port using ``ps6000aSetDigitalPortOn``.
+
+        Args:
+            port (DIGITAL_PORT): Digital port to enable.
+            logic_threshold_level (list[int]): Threshold level for each pin in millivolts.
+            hysteresis (DIGITAL_PORT_HYSTERESIS): Hysteresis level applied to all pins.
+        """
+
+        level_array = (ctypes.c_int16 * len(logic_threshold_level))(*logic_threshold_level)
+
+        self._call_attr_function(
+            "SetDigitalPortOn",
+            self.handle,
+            port,
+            level_array,
+            len(logic_threshold_level),
+            hysteresis,
+        )
+
+    def set_digital_port_off(self, port: DIGITAL_PORT) -> None:
+        """Disable a digital port using ``ps6000aSetDigitalPortOff``."""
+
+        self._call_attr_function(
+            "SetDigitalPortOff",
+            self.handle,
+            port,
+        )
+
+    def set_aux_io_mode(self, mode: AUX_IO_MODE) -> None:
+        """Configure the auxiliary I/O mode using ``ps6000aSetAuxIoMode``."""
+
+        self._call_attr_function(
+            "SetAuxIoMode",
+            self.handle,
+            mode,
+        )
 
     def set_simple_trigger(self, channel, threshold_mv, enable=True, direction=TRIGGER_DIR.RISING, delay=0, auto_trigger_ms=5_000):
         """

--- a/tests/digital_port_test.py
+++ b/tests/digital_port_test.py
@@ -1,0 +1,59 @@
+import ctypes
+from pypicosdk import (
+    ps6000a,
+    DIGITAL_PORT,
+    DIGITAL_PORT_HYSTERESIS,
+    AUX_IO_MODE,
+)
+
+
+def test_set_digital_port_on(monkeypatch):
+    scope = ps6000a("pytest")
+    captured = {}
+
+    def fake_call(name, handle, port, level_array, length, hysteresis):
+        captured["name"] = name
+        captured["port"] = port
+        captured["levels"] = [level_array[i] for i in range(length)]
+        captured["hysteresis"] = hysteresis
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    scope.set_digital_port_on(DIGITAL_PORT.PORT0, [100] * 2, DIGITAL_PORT_HYSTERESIS.NORMAL_100MV)
+
+    assert captured["name"] == "SetDigitalPortOn"
+    assert captured["port"] == DIGITAL_PORT.PORT0
+    assert captured["levels"] == [100, 100]
+    assert captured["hysteresis"] == DIGITAL_PORT_HYSTERESIS.NORMAL_100MV
+
+
+def test_set_digital_port_off(monkeypatch):
+    scope = ps6000a("pytest")
+    captured = {}
+
+    def fake_call(name, handle, port):
+        captured["name"] = name
+        captured["port"] = port
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    scope.set_digital_port_off(DIGITAL_PORT.PORT1)
+
+    assert captured["name"] == "SetDigitalPortOff"
+    assert captured["port"] == DIGITAL_PORT.PORT1
+
+
+def test_set_aux_io_mode(monkeypatch):
+    scope = ps6000a("pytest")
+    captured = {}
+
+    def fake_call(name, handle, mode):
+        captured["name"] = name
+        captured["mode"] = mode
+        return 0
+
+    monkeypatch.setattr(scope, "_call_attr_function", fake_call)
+    scope.set_aux_io_mode(AUX_IO_MODE.INPUT)
+
+    assert captured["name"] == "SetAuxIoMode"
+    assert captured["mode"] == AUX_IO_MODE.INPUT


### PR DESCRIPTION
## Summary
- expose digital port enums
- allow digital port control and aux IO mode on ps6000a
- test new digital port APIs

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0ccc10c0832789d154f88a237db3