### PR TITLE
Refactor trigger condition API

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -184,6 +184,11 @@ class CONDITION(ctypes.Structure):
     ]
 
 
+class PICO_CONDITION(CONDITION):
+    """Alias of :class:`CONDITION` for PicoSDK compatibility."""
+    pass
+
+
 class DIRECTION(ctypes.Structure):
     """Trigger direction for a channel."""
 
@@ -473,6 +478,7 @@ __all__ = [
     "CONDITIONS_INFO",
     "TRIGGER_CHANNEL_PROPERTIES",
     "CONDITION",
+    "PICO_CONDITION",
     "DIRECTION",
     "PICO_TRIGGER_INFO",
     "UNIT_INFO",

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -15,7 +15,6 @@ from .constants import (
     TRIGGER_STATE,
     THRESHOLD_MODE,
     THRESHOLD_DIRECTION,
-    CONDITIONS_INFO,
     RESOLUTION,
     TIME_UNIT,
     DIGITAL_PORT,
@@ -142,7 +141,7 @@ class ps6000a(PicoScopeBase):
         auto_trigger_us = auto_trigger_ms * 1000
         return super().set_trigger_channel_properties(properties, aux_output_enable, auto_trigger_us)
 
-    def set_advanced_trigger(self, properties, directions, conditions, aux_output_enable=0, auto_trigger_ms=0, action=CONDITIONS_INFO.CLEAR_CONDITIONS | CONDITIONS_INFO.ADD_CONDITION):
+    def set_advanced_trigger(self, properties, directions, conditions, aux_output_enable=0, auto_trigger_ms=0, action=ACTION.CLEAR_ALL | ACTION.ADD):
         """Configure an advanced trigger using millisecond units."""
 
         auto_trigger_us = auto_trigger_ms * 1000


### PR DESCRIPTION
## Summary
- refactor `set_trigger_channel_conditions` to configure a single condition
- adapt `set_advanced_trigger` to call the new API
- add `PICO_CONDITION` structure alias
- update `ps6000a` wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e408f1048832793f4ff2f1d63d7b9