### PR TITLE
Implement firmware update helpers

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -302,6 +302,46 @@ class PICO_TIME_UNIT(IntEnum):
     MS = 4
     S = 5
 
+
+class PICO_VERSION(ctypes.Structure):
+    """Firmware or driver version information.
+
+    Attributes:
+        major_: Major version number.
+        minor_: Minor version number.
+        revision_: Revision number.
+        build_: Build number.
+    """
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("major_", ctypes.c_int16),
+        ("minor_", ctypes.c_int16),
+        ("revision_", ctypes.c_int16),
+        ("build_", ctypes.c_int16),
+    ]
+
+
+class PICO_FIRMWARE_INFO(ctypes.Structure):
+    """Information describing firmware versions and updates.
+
+    Attributes:
+        firmwareType_: Firmware identifier as a :class:`UNIT_INFO` value.
+        currentVersion_: Currently installed :class:`PICO_VERSION`.
+        updateVersion_: Available update :class:`PICO_VERSION`.
+        updateRequired_: ``1`` if an update is required, otherwise ``0``.
+    """
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("firmwareType_", ctypes.c_uint32),
+        ("currentVersion_", PICO_VERSION),
+        ("updateVersion_", PICO_VERSION),
+        ("updateRequired_", ctypes.c_uint16),
+    ]
+
 class DIGITAL_PORT(IntEnum):
     """Digital port identifiers for the 6000A series."""
     PORT0 = 128
@@ -543,6 +583,8 @@ __all__ = [
     'SAMPLE_RATE',
     'TIME_UNIT',
     'PICO_TIME_UNIT',
+    'PICO_VERSION',
+    'PICO_FIRMWARE_INFO',
     'DIGITAL_PORT',
     'DIGITAL_PORT_HYSTERESIS',
     'AUXIO_MODE',

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -97,10 +97,65 @@ class ps6000a(PicoScopeBase):
             self.resolution,
         )
         return max_segments.value
-    
+
+    def ping_unit(self) -> bool:
+        """Check that the device is still connected.
+
+        This wraps ``ps6000aPingUnit`` which verifies communication with
+        the PicoScope. If the call succeeds the method returns ``True``.
+
+        Returns:
+            bool: ``True`` if the unit responded.
+        """
+
+        status = self._call_attr_function("PingUnit", self.handle)
+        return status == 0
+
+    def check_for_update(self, n_infos: int = 8) -> tuple[list, bool]:
+        """Query whether a firmware update is available for the device.
+
+        Args:
+            n_infos: Size of the firmware information buffer.
+
+        Returns:
+            tuple[list, bool]: ``(firmware_info, updates_required)`` where
+                ``firmware_info`` is a list of :class:`PICO_FIRMWARE_INFO`
+                structures and ``updates_required`` indicates whether any
+                firmware components require updating.
+        """
+
+        info_array = (PICO_FIRMWARE_INFO * n_infos)()
+        n_returned = ctypes.c_int16(n_infos)
+        updates_required = ctypes.c_uint16()
+        self._call_attr_function(
+            "CheckForUpdate",
+            self.handle,
+            info_array,
+            ctypes.byref(n_returned),
+            ctypes.byref(updates_required),
+        )
+
+        return list(info_array)[: n_returned.value], bool(updates_required.value)
+
+    def start_firmware_update(self, progress=None) -> None:
+        """Begin installing any available firmware update.
+
+        Args:
+            progress: Optional callback ``(handle, percent)`` that receives
+                progress updates as the firmware is written.
+        """
+
+        CALLBACK = ctypes.CFUNCTYPE(None, ctypes.c_int16, ctypes.c_uint16)
+        cb = CALLBACK(progress) if progress else None
+        self._call_attr_function(
+            "StartFirmwareUpdate",
+            self.handle,
+            cb,
+        )
+
     def get_timebase(self, timebase:int, samples:int, segment:int=0) -> None:
         """
-        This function calculates the sampling rate and maximum number of 
+        This function calculates the sampling rate and maximum number of
         samples for a given timebase under the specified conditions.
 
         Args:


### PR DESCRIPTION
## Summary
- expose firmware version structures in constants
- add PingUnit, CheckForUpdate and StartFirmwareUpdate methods for ps6000a

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5ebc6e8c832782aba4fabf7fefd0