### PR TITLE
Add ps6000a helper API bindings

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -315,6 +315,45 @@ class DIGITAL_PORT_HYSTERESIS(IntEnum):
     LOW_50MV = 3
 
 
+class PICO_CHANNEL_FLAGS(IntEnum):
+    """Bit flags for enabled channels used by ``ps6000aChannelCombinationsStateless``."""
+
+    CHANNEL_A_FLAGS = 1
+    CHANNEL_B_FLAGS = 2
+    CHANNEL_C_FLAGS = 4
+    CHANNEL_D_FLAGS = 8
+    CHANNEL_E_FLAGS = 16
+    CHANNEL_F_FLAGS = 32
+    CHANNEL_G_FLAGS = 64
+    CHANNEL_H_FLAGS = 128
+
+    PORT0_FLAGS = 65536
+    PORT1_FLAGS = 131072
+    PORT2_FLAGS = 262144
+    PORT3_FLAGS = 524288
+
+
+class PICO_CONNECT_PROBE_RANGE(IntEnum):
+    """Input range identifiers for ``get_analogue_offset_limits``."""
+
+    CONNECT_PROBE_OFF = 1024
+
+    D9_BNC_10MV = 0
+    D9_BNC_20MV = 1
+    D9_BNC_50MV = 2
+    D9_BNC_100MV = 3
+    D9_BNC_200MV = 4
+    D9_BNC_500MV = 5
+    D9_BNC_1V = 6
+    D9_BNC_2V = 7
+    D9_BNC_5V = 8
+    D9_BNC_10V = 9
+    D9_BNC_20V = 10
+    D9_BNC_50V = 11
+    D9_BNC_100V = 12
+    D9_BNC_200V = 13
+
+
 class AUXIO_MODE(IntEnum):
     """Operating modes for the AUX IO connector."""
 
@@ -545,6 +584,8 @@ __all__ = [
     'PICO_TIME_UNIT',
     'DIGITAL_PORT',
     'DIGITAL_PORT_HYSTERESIS',
+    'PICO_CHANNEL_FLAGS',
+    'PICO_CONNECT_PROBE_RANGE',
     'AUXIO_MODE',
     'PICO_TRIGGER_STATE',
     'PICO_STREAMING_DATA_INFO',

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -196,6 +196,63 @@ class ps6000a(PicoScopeBase):
             mode,
         )
 
+    def channel_combinations_stateless(
+        self, resolution: RESOLUTION, timebase: int
+    ) -> list[PICO_CHANNEL_FLAGS]:
+        """Return valid channel flag combinations for a configuration."""
+
+        size = 8
+        func = self._get_attr_function("ChannelCombinationsStateless")
+        while True:
+            combos = (ctypes.c_uint32 * size)()
+            n_combos = ctypes.c_uint32(size)
+            status = func(
+                self.handle,
+                combos,
+                ctypes.byref(n_combos),
+                resolution,
+                ctypes.c_uint32(timebase),
+            )
+            if status == 401:
+                size = n_combos.value
+                continue
+            self._error_handler(status)
+            return [PICO_CHANNEL_FLAGS(combos[i]) for i in range(n_combos.value)]
+
+    def get_accessory_info(self, channel: CHANNEL, info: UNIT_INFO) -> str:
+        """Retrieve information about an accessory connected to ``channel``."""
+
+        buf_len = 64
+        string = ctypes.create_string_buffer(buf_len)
+        req_size = ctypes.c_int16(buf_len)
+        self._call_attr_function(
+            "GetAccessoryInfo",
+            self.handle,
+            channel,
+            string,
+            ctypes.c_int16(buf_len),
+            ctypes.byref(req_size),
+            ctypes.c_uint32(info),
+        )
+        return string.value.decode()
+
+    def get_analogue_offset_limits(
+        self, range: PICO_CONNECT_PROBE_RANGE, coupling: COUPLING
+    ) -> tuple[float, float]:
+        """Get the allowed analogue offset range for ``range`` and ``coupling``."""
+
+        max_v = ctypes.c_double()
+        min_v = ctypes.c_double()
+        self._call_attr_function(
+            "GetAnalogueOffsetLimits",
+            self.handle,
+            range,
+            coupling,
+            ctypes.byref(max_v),
+            ctypes.byref(min_v),
+        )
+        return max_v.value, min_v.value
+
     def set_simple_trigger(self, channel, threshold_mv=0, enable=True, direction=TRIGGER_DIR.RISING, delay=0, auto_trigger_ms=5_000):
         """
         Sets up a simple trigger from a specified channel and threshold in mV.


### PR DESCRIPTION
## Summary
- implement `PICO_CHANNEL_FLAGS` and `PICO_CONNECT_PROBE_RANGE` enums
- expose new enums in `__all__`
- add ps6000a wrappers for `ChannelCombinationsStateless`, `GetAccessoryInfo` and
  `GetAnalogueOffsetLimits`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5f08c35c8327bb76b6a9eff9a146