### PR TITLE
Add streaming latest values helper

### DIFF
--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -1,4 +1,6 @@
 import ctypes
+from typing import Sequence
+
 from .constants import *
 from .base import PicoSDKException, PicoScopeBase
 
@@ -792,4 +794,34 @@ class ps6000a(PicoScopeBase):
         time_axis = self.get_time_axis(timebase, actual_samples)
 
         return channels_buffer, time_axis
+
+    def get_streaming_latest_values(
+        self, streaming_data_info: Sequence[PICO_STREAMING_DATA_INFO]
+    ) -> tuple[list[PICO_STREAMING_DATA_INFO], PICO_STREAMING_DATA_TRIGGER_INFO]:
+        """Retrieve the most recent streaming data from the device.
+
+        Args:
+            streaming_data_info: Sequence of
+                :class:`PICO_STREAMING_DATA_INFO` structures describing the
+                buffers to populate.
+
+        Returns:
+            tuple[list[PICO_STREAMING_DATA_INFO],
+            :class:`PICO_STREAMING_DATA_TRIGGER_INFO`]: ``(data_info, trigger)``
+            with updated streaming data and trigger information.
+        """
+
+        array_type = PICO_STREAMING_DATA_INFO * len(streaming_data_info)
+        data_array = array_type(*streaming_data_info)
+        trigger_info = PICO_STREAMING_DATA_TRIGGER_INFO()
+
+        self._call_attr_function(
+            "GetStreamingLatestValues",
+            self.handle,
+            data_array,
+            len(streaming_data_info),
+            ctypes.byref(trigger_info),
+        )
+
+        return list(data_array), trigger_info
 __all__ = ['ps6000a']

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -1,5 +1,4 @@
 import ctypes
-from typing import Sequence
 
 from .constants import *
 from .base import PicoSDKException, PicoScopeBase
@@ -796,12 +795,12 @@ class ps6000a(PicoScopeBase):
         return channels_buffer, time_axis
 
     def get_streaming_latest_values(
-        self, streaming_data_info: Sequence[PICO_STREAMING_DATA_INFO]
+        self, streaming_data_info: list[PICO_STREAMING_DATA_INFO]
     ) -> tuple[list[PICO_STREAMING_DATA_INFO], PICO_STREAMING_DATA_TRIGGER_INFO]:
         """Retrieve the most recent streaming data from the device.
 
         Args:
-            streaming_data_info: Sequence of
+            streaming_data_info: list of
                 :class:`PICO_STREAMING_DATA_INFO` structures describing the
                 buffers to populate.
 


### PR DESCRIPTION
## Summary
- add `Sequence` import for streaming
- implement `get_streaming_latest_values()` API method on `ps6000a`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e68926aa48327a5fd30b8a226daf7