### PR TITLE
Add streaming helper no_of_streaming_values

### DIFF
--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -265,6 +265,17 @@ class ps6000a(PicoScopeBase):
             cb,
         )
 
+    def no_of_streaming_values(self) -> int:
+        """Return the number of values currently available while streaming."""
+
+        count = ctypes.c_uint64()
+        self._call_attr_function(
+            "NoOfStreamingValues",
+            self.handle,
+            ctypes.byref(count),
+        )
+        return count.value
+
     def get_timebase(self, timebase:int, samples:int, segment:int=0) -> None:
         """
         This function calculates the sampling rate and maximum number of


### PR DESCRIPTION
## Summary
- expose `no_of_streaming_values()` in ps6000a

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6892bcfc8327aca3281f071796b5