### PR TITLE
Add set_device_resolution helper

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -419,7 +419,25 @@ class PicoScopeBase:
             ctypes.byref(max_value)
         )
         return max_value.value
-    
+
+    def set_device_resolution(self, resolution: RESOLUTION) -> None:
+        """Change the oscilloscope's sampling resolution.
+
+        This wraps the ``SetDeviceResolution`` driver function and updates
+        ``min_adc_value`` and ``max_adc_value`` to match the new resolution.
+
+        Args:
+            resolution: Desired device resolution from :class:`RESOLUTION`.
+        """
+
+        self._call_attr_function(
+            "SetDeviceResolution",
+            self.handle,
+            resolution,
+        )
+        self.resolution = resolution
+        self.min_adc_value, self.max_adc_value = self._get_adc_limits()
+
     def get_time_axis(self, timebase:int, samples:int) -> list:
         """
         Return an array of time values based on the timebase and number

--- a/tests/device_resolution_test.py
+++ b/tests/device_resolution_test.py
@@ -1,0 +1,20 @@
+from pypicosdk import ps6000a, RESOLUTION
+
+
+def test_set_device_resolution_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope._get_adc_limits = lambda: (1, 2)
+    scope.set_device_resolution(RESOLUTION._12BIT)
+    assert called['name'] == 'SetDeviceResolution'
+    assert scope.resolution == RESOLUTION._12BIT
+    assert scope.min_adc_value == 1
+    assert scope.max_adc_value == 2
+


### PR DESCRIPTION
## Summary
- add `set_device_resolution` to `PicoScopeBase`
- test that SetDeviceResolution is invoked and updates limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710288e4dc83279ce008d26beb25cb