### PR TITLE
Implement GetMaximumAvailableMemory wrapper

### DIFF
--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -97,10 +97,35 @@ class ps6000a(PicoScopeBase):
             self.resolution,
         )
         return max_segments.value
-    
+
+    def get_maximum_available_memory(self) -> int:
+        """Return the maximum sample depth for the current resolution.
+
+        Wraps ``ps6000aGetMaximumAvailableMemory`` to query how many samples
+        can be captured at ``self.resolution``.
+
+        Returns:
+            int: Maximum number of samples supported.
+
+        Raises:
+            PicoSDKException: If the device has not been opened.
+        """
+
+        if self.resolution is None:
+            raise PicoSDKException("Device has not been initialized, use open_unit()")
+
+        max_samples = ctypes.c_uint64()
+        self._call_attr_function(
+            "GetMaximumAvailableMemory",
+            self.handle,
+            ctypes.byref(max_samples),
+            self.resolution,
+        )
+        return max_samples.value
+
     def get_timebase(self, timebase:int, samples:int, segment:int=0) -> None:
         """
-        This function calculates the sampling rate and maximum number of 
+        This function calculates the sampling rate and maximum number of
         samples for a given timebase under the specified conditions.
 
         Args:

--- a/tests/maximum_available_memory_test.py
+++ b/tests/maximum_available_memory_test.py
@@ -1,0 +1,33 @@
+import sys
+import os
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, repo_root)
+if 'pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk']
+if 'pypicosdk.constants' in sys.modules:
+    del sys.modules['pypicosdk.constants']
+if 'pypicosdk.pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk.pypicosdk']
+
+from pypicosdk import ps6000a, RESOLUTION
+
+
+def test_get_maximum_available_memory_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        # simulate SDK writing to the output pointer
+        import ctypes
+        ptr = ctypes.cast(args[1], ctypes.POINTER(ctypes.c_uint64))
+        ptr.contents.value = 1234
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.resolution = RESOLUTION._12BIT
+    result = scope.get_maximum_available_memory()
+    assert called['name'] == 'GetMaximumAvailableMemory'
+    assert result == 1234


### PR DESCRIPTION
## Summary
- add get_maximum_available_memory wrapper to ps6000a class
- test that GetMaximumAvailableMemory is invoked correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687102c05efc832795e91d13ac038d3e