### PR TITLE
Implement GetAccessoryInfo wrapper

### DIFF
--- a/pypicosdk/base.py
+++ b/pypicosdk/base.py
@@ -241,6 +241,36 @@ class PicoScopeBase:
                 str: Returns serial, e.g., "JR628/0017".
         """
         return self.get_unit_info(UNIT_INFO.PICO_BATCH_AND_SERIAL)
+
+    def get_accessory_info(self, channel: CHANNEL, info: UNIT_INFO) -> str:
+        """Return accessory details for the given channel.
+
+        This wraps the driver ``GetAccessoryInfo`` call which retrieves
+        information about any accessory attached to ``channel``.
+
+        Args:
+            channel: Channel the accessory is connected to.
+            info: Information field requested from :class:`UNIT_INFO`.
+
+        Returns:
+            str: Information string provided by the driver.
+        """
+
+        string = ctypes.create_string_buffer(16)
+        string_length = ctypes.c_int16(32)
+        required_size = ctypes.c_int16(32)
+
+        self._call_attr_function(
+            "GetAccessoryInfo",
+            self.handle,
+            channel,
+            string,
+            string_length,
+            ctypes.byref(required_size),
+            ctypes.c_uint32(info),
+        )
+
+        return string.value.decode()
     
     def _get_enabled_channel_flags(self) -> int:
         """

--- a/tests/accessory_info_test.py
+++ b/tests/accessory_info_test.py
@@ -1,0 +1,27 @@
+import sys
+import os
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, repo_root)
+if 'pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk']
+if 'pypicosdk.constants' in sys.modules:
+    del sys.modules['pypicosdk.constants']
+if 'pypicosdk.pypicosdk' in sys.modules:
+    del sys.modules['pypicosdk.pypicosdk']
+
+from pypicosdk import ps6000a, CHANNEL, UNIT_INFO
+
+
+def test_get_accessory_info_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        return 0
+
+    scope._call_attr_function = fake_call
+    scope.get_accessory_info(CHANNEL.A, UNIT_INFO.PICO_BATCH_AND_SERIAL)
+    assert called['name'] == 'GetAccessoryInfo'


### PR DESCRIPTION
## Summary
- add `get_accessory_info` to `PicoScopeBase`
- test invocation of the new wrapper

## Testing
- `pytest -q`

