### PR TITLE
Add analogue offset limits wrapper

### DIFF
--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -123,6 +123,37 @@ class ps6000a(PicoScopeBase):
         )
         return max_samples.value
 
+    def get_analogue_offset_limits(
+        self,
+        range: RANGE,
+        coupling: COUPLING,
+    ) -> dict:
+        """Return allowable analogue offset range for the given settings.
+
+        This wraps ``ps6000aGetAnalogueOffsetLimits`` to query the maximum
+        and minimum analogue offset voltages permitted when a channel is
+        configured with ``range`` and ``coupling``.
+
+        Args:
+            range: Input voltage range as a :class:`RANGE` value.
+            coupling: Channel coupling mode from :class:`COUPLING`.
+
+        Returns:
+            dict: ``{"maximum_voltage": float, "minimum_voltage": float}``.
+        """
+
+        maximum = ctypes.c_double()
+        minimum = ctypes.c_double()
+        self._call_attr_function(
+            "GetAnalogueOffsetLimits",
+            self.handle,
+            range,
+            coupling,
+            ctypes.byref(maximum),
+            ctypes.byref(minimum),
+        )
+        return {"maximum_voltage": maximum.value, "minimum_voltage": minimum.value}
+
     def get_timebase(self, timebase:int, samples:int, segment:int=0) -> None:
         """
         This function calculates the sampling rate and maximum number of

--- a/tests/analogue_offset_limits_test.py
+++ b/tests/analogue_offset_limits_test.py
@@ -1,0 +1,22 @@
+from pypicosdk import ps6000a, RANGE, COUPLING
+
+
+def test_get_analogue_offset_limits_invocation():
+    scope = ps6000a('pytest')
+    called = {}
+
+    def fake_call(name, *args):
+        called['name'] = name
+        called['args'] = args
+        import ctypes
+        max_ptr = ctypes.cast(args[3], ctypes.POINTER(ctypes.c_double))
+        min_ptr = ctypes.cast(args[4], ctypes.POINTER(ctypes.c_double))
+        max_ptr.contents.value = 1.2
+        min_ptr.contents.value = -0.8
+        return 0
+
+    scope._call_attr_function = fake_call
+    result = scope.get_analogue_offset_limits(RANGE.V1, COUPLING.DC)
+    assert called['name'] == 'GetAnalogueOffsetLimits'
+    assert result == {'maximum_voltage': 1.2, 'minimum_voltage': -0.8}
+


### PR DESCRIPTION
## Summary
- expose `ps6000aGetAnalogueOffsetLimits` via `get_analogue_offset_limits`
- test analogue offset wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687107ef646c8327a443b3636dc3b20a