### PR TITLE
Implement overvoltage reset wrapper

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -410,6 +410,22 @@ class AUXIO_MODE(IntEnum):
     TRIGGER_OUT = 3
 
 
+class PICO_CHANNEL_OVERVOLTAGE_TRIPPED(ctypes.Structure):
+    """Status flag indicating whether a channel's input protection tripped.
+
+    Attributes:
+        channel_: Channel identifier as a :class:`CHANNEL` value.
+        tripped_: ``1`` if the channel has tripped due to overvoltage.
+    """
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("tripped_", ctypes.c_uint8),
+    ]
+
+
 class PICO_TRIGGER_STATE(IntEnum):
     """Trigger state values used in :class:`PICO_CONDITION`."""
 
@@ -629,6 +645,7 @@ __all__ = [
     'PICO_CHANNEL_FLAGS',
     'PICO_CONNECT_PROBE_RANGE',
     'AUXIO_MODE',
+    'PICO_CHANNEL_OVERVOLTAGE_TRIPPED',
     'PICO_TRIGGER_STATE',
     'PICO_STREAMING_DATA_INFO',
     'PICO_STREAMING_DATA_TRIGGER_INFO',

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -266,6 +266,26 @@ class ps6000a(PicoScopeBase):
             cb,
         )
 
+    def reset_channels_and_report_all_channels_overvoltage_trip_status(self) -> list[PICO_CHANNEL_OVERVOLTAGE_TRIPPED]:
+        """Reset channels and return overvoltage trip status for each.
+
+        Wraps ``ps6000aResetChannelsAndReportAllChannelsOvervoltageTripStatus``.
+
+        Returns:
+            list[PICO_CHANNEL_OVERVOLTAGE_TRIPPED]: Trip status for all channels.
+        """
+
+        n_channels = len(CHANNEL_NAMES)
+        status_array = (PICO_CHANNEL_OVERVOLTAGE_TRIPPED * n_channels)()
+        self._call_attr_function(
+            "ResetChannelsAndReportAllChannelsOvervoltageTripStatus",
+            self.handle,
+            status_array,
+            ctypes.c_uint8(n_channels),
+        )
+
+        return list(status_array)
+
     def no_of_streaming_values(self) -> int:
         """Return the number of values currently available while streaming."""
 


### PR DESCRIPTION
## Summary
- add `PICO_CHANNEL_OVERVOLTAGE_TRIPPED` structure to constants
- implement `reset_channels_and_report_all_channels_overvoltage_trip_status` in ps6000a wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710981e6988327a0e9b11bbfbdf9d2