### PR TITLE
Add overvoltage trip status helper

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -355,6 +355,22 @@ class DIGITAL_PORT_HYSTERESIS(IntEnum):
     LOW_50MV = 3
 
 
+class PICO_CHANNEL_OVERVOLTAGE_TRIPPED(ctypes.Structure):
+    """Status flag indicating an overvoltage trip on a channel.
+
+    Attributes:
+        channel_: Channel identifier as a :class:`CHANNEL` value.
+        tripped_: ``1`` if an overvoltage trip occurred, otherwise ``0``.
+    """
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("tripped_", ctypes.c_uint8),
+    ]
+
+
 class PICO_CHANNEL_FLAGS(IntEnum):
     """Bit flags for enabled channels used by ``ps6000aChannelCombinationsStateless``."""
 
@@ -626,6 +642,7 @@ __all__ = [
     'PICO_FIRMWARE_INFO',
     'DIGITAL_PORT',
     'DIGITAL_PORT_HYSTERESIS',
+    'PICO_CHANNEL_OVERVOLTAGE_TRIPPED',
     'PICO_CHANNEL_FLAGS',
     'PICO_CONNECT_PROBE_RANGE',
     'AUXIO_MODE',

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -277,6 +277,32 @@ class ps6000a(PicoScopeBase):
         )
         return count.value
 
+    def report_all_channels_overvoltage_trip_status(
+        self,
+    ) -> list[PICO_CHANNEL_OVERVOLTAGE_TRIPPED]:
+        """Return the overvoltage trip status for each channel.
+
+        This wraps ``ps6000aReportAllChannelsOvervoltageTripStatus`` to
+        query whether any channel's 50 Ω input protection has tripped.
+
+        Returns:
+            list[PICO_CHANNEL_OVERVOLTAGE_TRIPPED]: Trip status for all
+            channels.
+        """
+
+        n_channels = len(CHANNEL_NAMES)
+        array_type = PICO_CHANNEL_OVERVOLTAGE_TRIPPED * n_channels
+        status_array = array_type()
+
+        self._call_attr_function(
+            "ReportAllChannelsOvervoltageTripStatus",
+            self.handle,
+            status_array,
+            n_channels,
+        )
+
+        return list(status_array)
+
     def get_timebase(self, timebase:int, samples:int, segment:int=0) -> None:
         """
         This function calculates the sampling rate and maximum number of


### PR DESCRIPTION
## Summary
- expose `PICO_CHANNEL_OVERVOLTAGE_TRIPPED` structure
- add wrapper for `ReportAllChannelsOvervoltageTripStatus`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710a6fc3a083278bd4aabb7e557654