### PR TITLE
Implement GetScalingValues wrapper

### DIFF
--- a/pypicosdk/constants.py
+++ b/pypicosdk/constants.py
@@ -394,6 +394,42 @@ class PICO_CONNECT_PROBE_RANGE(IntEnum):
     D9_BNC_200V = 13
 
 
+class PICO_PROBE_RANGE_INFO(IntEnum):
+    """Probe attenuation identifiers for ``get_scaling_values``."""
+
+    PROBE_NONE_NV = 0
+    X1_PROBE_NV = 1
+    X10_PROBE_NV = 10
+
+
+class PICO_SCALING_FACTORS_VALUES(ctypes.Structure):
+    """Scaling factors for a channel and range."""
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("range_", ctypes.c_int32),
+        ("offset_", ctypes.c_int16),
+        ("scalingFactor_", ctypes.c_double),
+    ]
+
+
+class PICO_SCALING_FACTORS_FOR_RANGE_TYPES_VALUES(ctypes.Structure):
+    """Scaling factors for a probe range type."""
+
+    _pack_ = 1
+
+    _fields_ = [
+        ("channel_", ctypes.c_int32),
+        ("rangeMin_", ctypes.c_int64),
+        ("rangeMax_", ctypes.c_int64),
+        ("rangeType_", ctypes.c_int32),
+        ("offset_", ctypes.c_int16),
+        ("scalingFactor_", ctypes.c_double),
+    ]
+
+
 class AUXIO_MODE(IntEnum):
     """Operating modes for the AUX IO connector."""
 
@@ -628,6 +664,9 @@ __all__ = [
     'DIGITAL_PORT_HYSTERESIS',
     'PICO_CHANNEL_FLAGS',
     'PICO_CONNECT_PROBE_RANGE',
+    'PICO_PROBE_RANGE_INFO',
+    'PICO_SCALING_FACTORS_VALUES',
+    'PICO_SCALING_FACTORS_FOR_RANGE_TYPES_VALUES',
     'AUXIO_MODE',
     'PICO_TRIGGER_STATE',
     'PICO_STREAMING_DATA_INFO',

--- a/pypicosdk/ps6000a.py
+++ b/pypicosdk/ps6000a.py
@@ -432,6 +432,26 @@ class ps6000a(PicoScopeBase):
         )
         return max_v.value, min_v.value
 
+    def get_scaling_values(self, n_channels: int = 8) -> list[PICO_SCALING_FACTORS_VALUES]:
+        """Return probe scaling factors for each channel.
+
+        Args:
+            n_channels: Number of channel entries to retrieve.
+
+        Returns:
+            list[PICO_SCALING_FACTORS_VALUES]: Scaling factors for ``n_channels`` channels.
+        """
+
+        array_type = PICO_SCALING_FACTORS_VALUES * n_channels
+        values = array_type()
+        self._call_attr_function(
+            "GetScalingValues",
+            self.handle,
+            values,
+            ctypes.c_int16(n_channels),
+        )
+        return list(values)
+
     def set_simple_trigger(self, channel, threshold_mv=0, enable=True, direction=TRIGGER_DIR.RISING, delay=0, auto_trigger_ms=5_000):
         """
         Sets up a simple trigger from a specified channel and threshold in mV.


### PR DESCRIPTION
## Summary
- add constants for scaling values and probe range info
- expose new constants in `__all__`
- implement `ps6000a.get_scaling_values`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710aaf06208327bed35e22522fc7fa